### PR TITLE
Unified User+Gestionnaire login

### DIFF
--- a/app/controllers/gestionnaires/passwords_controller.rb
+++ b/app/controllers/gestionnaires/passwords_controller.rb
@@ -1,4 +1,6 @@
 class Gestionnaires::PasswordsController < Devise::PasswordsController
+  after_action :try_to_authenticate_user, only: %i(update)
+
   # GET /resource/password/new
   # def new
   #   super
@@ -29,4 +31,11 @@ class Gestionnaires::PasswordsController < Devise::PasswordsController
   # def after_sending_reset_password_instructions_path_for(resource_name)
   #   super(resource_name)
   # end
+
+  def try_to_authenticate_user
+    if gestionnaire_signed_in?
+      user = User.find_by(email: current_gestionnaire.email)
+      sign_in user if user
+    end
+  end
 end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,4 +1,6 @@
 class Users::PasswordsController < Devise::PasswordsController
+  after_action :try_to_authenticate_gestionnaire, only: %i(update)
+
   # GET /resource/password/new
   # def new
   #   super
@@ -29,4 +31,11 @@ class Users::PasswordsController < Devise::PasswordsController
   # def after_sending_reset_password_instructions_path_for(resource_name)
   #   super(resource_name)
   # end
+
+  def try_to_authenticate_gestionnaire
+    if user_signed_in?
+      gestionnaire = Gestionnaire.find_by(email: current_user.email)
+      sign_in gestionnaire if gestionnaire
+    end
+  end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -22,27 +22,45 @@ class Users::SessionsController < Sessions::SessionsController
 
 #POST /resource/sign_in
   def create
-    super
+    try_to_authenticate(User)
+    try_to_authenticate(Gestionnaire)
 
-    current_user.update_attributes(loged_in_with_france_connect: '')
+    if user_signed_in?
+      current_user.update_attributes(loged_in_with_france_connect: '')
+    end
+
+    if gestionnaire_signed_in?
+      redirect_to backoffice_path
+    elsif user_signed_in?
+      redirect_to after_sign_in_path_for(:user)
+    else
+      new
+      render :new, status: 401
+    end
   end
 
 # DELETE /resource/sign_out
   def destroy
-    connected_with_france_connect = current_user.loged_in_with_france_connect
-    current_user.update_attributes(loged_in_with_france_connect: '')
-
-    signed_out = (Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name))
-    set_flash_message :notice, :signed_out if signed_out && is_flashing_format?
-    yield if block_given?
-
-    if connected_with_france_connect == 'entreprise'
-      redirect_to FRANCE_CONNECT.entreprise_logout_endpoint
-    elsif connected_with_france_connect == 'particulier'
-      redirect_to FRANCE_CONNECT.particulier_logout_endpoint
-    else
-      respond_to_on_destroy
+    if gestionnaire_signed_in?
+      sign_out :gestionnaire
     end
+
+    if user_signed_in?
+      connected_with_france_connect = current_user.loged_in_with_france_connect
+      current_user.update_attributes(loged_in_with_france_connect: '')
+
+      sign_out :user
+
+      if connected_with_france_connect == 'entreprise'
+        redirect_to FRANCE_CONNECT.entreprise_logout_endpoint
+        return
+      elsif connected_with_france_connect == 'particulier'
+        redirect_to FRANCE_CONNECT.particulier_logout_endpoint
+        return
+      end
+    end
+
+    respond_to_on_destroy
   end
 
   def no_procedure
@@ -61,5 +79,14 @@ class Users::SessionsController < Sessions::SessionsController
     return nil if session["user_return_to"].nil?
 
     NumberService.to_number session["user_return_to"].split("?procedure_id=").second
+  end
+
+  def try_to_authenticate(klass)
+    if resource = klass.find_for_database_authentication(email: params[:user][:email])
+      if resource.valid_password?(params[:user][:password])
+        sign_in resource
+        set_flash_message :notice, :signed_in
+      end
+    end
   end
 end

--- a/app/models/gestionnaire.rb
+++ b/app/models/gestionnaire.rb
@@ -14,6 +14,7 @@ class Gestionnaire < ActiveRecord::Base
 
   after_create :build_default_preferences_list_dossier
   after_create :build_default_preferences_smart_listing_page
+  after_save :sync_credentials
 
   def dossiers_follow
     dossiers.joins(:follows).where("follows.gestionnaire_id = #{id}")
@@ -83,5 +84,17 @@ class Gestionnaire < ActiveRecord::Base
                }]
 
     couples.include?({table: table, column: column})
+  end
+
+  def sync_credentials
+    if email_changed? || encrypted_password_changed?
+      user = User.find_by(email: email_was)
+      if user
+        return user.update_columns(
+          email: email,
+          encrypted_password: encrypted_password)
+      end
+    end
+    true
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,8 @@ class User < ActiveRecord::Base
   delegate :given_name, :family_name, :email_france_connect, :gender, :birthdate, :birthplace, :france_connect_particulier_id, to: :france_connect_information
   accepts_nested_attributes_for :france_connect_information
 
+  after_update :sync_credentials
+
   def self.find_for_france_connect email, siret
     user = User.find_by_email(email)
     if user.nil?
@@ -32,5 +34,19 @@ class User < ActiveRecord::Base
 
   def invite? dossier_id
     invites.pluck(:dossier_id).include?(dossier_id.to_i)
+  end
+
+  private
+
+  def sync_credentials
+    if email_changed? || encrypted_password_changed?
+      gestionnaire = Gestionnaire.find_by(email: email_was)
+      if gestionnaire
+        return gestionnaire.update_columns(
+          email: email,
+          encrypted_password: encrypted_password)
+      end
+    end
+    true
   end
 end

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -7,24 +7,29 @@
 %a{href: '/'}
   = image_tag('logo-tps.png', class: 'logo')
 
-- if gestionnaire_signed_in?
-  %a{href: (current_gestionnaire.procedure_filter.blank? ? '/' : backoffice_dossiers_procedure_path(current_gestionnaire.procedure_filter)), class: 'btn btn-md'}
+- if gestionnaire_signed_in? && user_signed_in?
+  %a{href: (current_gestionnaire.procedure_filter.blank? ? backoffice_dossiers_path : backoffice_dossiers_procedure_path(current_gestionnaire.procedure_filter)), class: 'btn btn-md'}
+    Dossiers
+  %a{href: users_dossiers_path, class: 'btn btn-md'}
+    Mes Dossiers
+- elsif gestionnaire_signed_in?
+  %a{href: (current_gestionnaire.procedure_filter.blank? ? backoffice_dossiers_path : backoffice_dossiers_procedure_path(current_gestionnaire.procedure_filter)), class: 'btn btn-md'}
     Mes Dossiers
 - elsif user_signed_in?
-  %a{href: '/', class: 'btn btn-md'}
+  %a{href: users_dossiers_path, class: 'btn btn-md'}
     Mes Dossiers
 - elsif administrateur_signed_in?
-  %a{href: '/', class: 'btn btn-md'}
+  %a{href: admin_procedures_path, class: 'btn btn-md'}
     Mes Procédures
 
 #sign_out
-  -if gestionnaire_signed_in?
+  -if user_signed_in?
+    = render partial: 'users/login_banner'
+  -elsif gestionnaire_signed_in?
     = render partial: 'gestionnaires/login_banner'
   -elsif administrateur_signed_in?
     = render partial: 'administrateurs/login_banner'
-  - elsif user_signed_in?
-    = render partial: 'users/login_banner'
-  - else
+  -else
     = link_to "Utilisateur", '/users/sign_in', method: :get, :class => 'btn btn-md'
     = link_to "Accompagnateur", '/gestionnaires/sign_in', method: :get, :class => 'btn btn-md'
     = link_to "Administrateur", '/administrateurs/sign_in', method: :get, :class => 'btn btn-md'

--- a/spec/controllers/gestionnaires/passwords_controller_spec.rb
+++ b/spec/controllers/gestionnaires/passwords_controller_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+describe Gestionnaires::PasswordsController, type: :controller do
+  before do
+    @request.env["devise.mapping"] = Devise.mappings[:gestionnaire]
+  end
+
+  describe "update" do
+    context "when associated gestionnaire" do
+      let(:gestionnaire) { create(:gestionnaire, email: 'unique@plop.com', password: 'password') }
+      let(:user) { create(:user, email: 'unique@plop.com', password: 'password') }
+
+      before do
+        @token = gestionnaire.send(:set_reset_password_token)
+        user # make sure it's created
+      end
+
+      it "also signs user in" do
+        put :update, gestionnaire: {
+          reset_password_token: @token,
+          password: "supersecret",
+          password_confirmation: "supersecret",
+        }
+        expect(subject.current_gestionnaire).to eq(gestionnaire)
+        expect(subject.current_user).to eq(user)
+      end
+    end
+  end
+end

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+describe Users::PasswordsController, type: :controller do
+  before do
+    @request.env["devise.mapping"] = Devise.mappings[:user]
+  end
+
+  describe "update" do
+    context "when associated gestionnaire" do
+      let(:user) { create(:user, email: 'unique@plop.com', password: 'password') }
+      let(:gestionnaire) { create(:gestionnaire, email: 'unique@plop.com', password: 'password') }
+
+      before do
+        @token = user.send(:set_reset_password_token)
+        gestionnaire # make sure it's created
+      end
+
+      it "also signs gestionnaire in" do
+        put :update, user: {
+          reset_password_token: @token,
+          password: "supersecret",
+          password_confirmation: "supersecret",
+        }
+        expect(subject.current_user).to eq(user)
+        expect(subject.current_gestionnaire).to eq(gestionnaire)
+      end
+    end
+  end
+end

--- a/spec/models/gestionnaire_spec.rb
+++ b/spec/models/gestionnaire_spec.rb
@@ -184,4 +184,15 @@ describe Gestionnaire, type: :model do
       end
     end
   end
+
+  it 'syncs credentials to associated user' do
+    gestionnaire = create(:gestionnaire)
+    user = create(:user, email: gestionnaire.email)
+
+    gestionnaire.update_attributes(email: 'whoami@plop.com', password: 'super secret')
+
+    user.reload
+    expect(user.email).to eq('whoami@plop.com')
+    expect(user.valid_password?('super secret')).to be(true)
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -72,4 +72,15 @@ describe User, type: :model do
       it { is_expected.to be_falsey }
     end
   end
+
+  it 'syncs credentials to associated gestionnaire' do
+    user = create(:user)
+    gestionnaire = create(:gestionnaire, email: user.email)
+
+    user.update_attributes(email: 'whoami@plop.com', password: 'super secret')
+
+    gestionnaire.reload
+    expect(gestionnaire.email).to eq('whoami@plop.com')
+    expect(gestionnaire.valid_password?('super secret')).to be(true)
+  end
 end


### PR DESCRIPTION
Hack into `users/sessions` to sign in/out a gestionnaire along with a user when credentials match. Also syncs credentials to the counterpart when they're changed for either one.

Maybe we'd like to have a feature flip to allow or disallow the credential sync for some installations only?