### PR TITLE
Unified login (more) + OpenSimplif

### DIFF
--- a/app/models/gestionnaire.rb
+++ b/app/models/gestionnaire.rb
@@ -14,7 +14,7 @@ class Gestionnaire < ActiveRecord::Base
 
   after_create :build_default_preferences_list_dossier
   after_create :build_default_preferences_smart_listing_page
-  after_save :sync_credentials
+  after_update :sync_credentials, if: -> { Features.unified_login }
 
   def dossiers_follow
     dossiers.joins(:follows).where("follows.gestionnaire_id = #{id}")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,8 +15,7 @@ class User < ActiveRecord::Base
 
   delegate :given_name, :family_name, :email_france_connect, :gender, :birthdate, :birthplace, :france_connect_particulier_id, to: :france_connect_information
   accepts_nested_attributes_for :france_connect_information
-
-  after_update :sync_credentials
+  after_update :sync_credentials, if: -> { Features.unified_login }
 
   def self.find_for_france_connect email, siret
     user = User.find_by_email(email)

--- a/app/views/backoffice/dossiers/_onglets.html.haml
+++ b/app/views/backoffice/dossiers/_onglets.html.haml
@@ -1,6 +1,3 @@
-=link_to 'Tous mes dossiers en CSV', backoffice_download_dossiers_tps_path, {class: 'btn btn-success btn-sm', style: 'float: right; margin-right: 4%; margin-top: 7px'}
-%h1 Gestion des dossiers
-
 #filter_by_procedure{style:'margin-left: 5%'}
   %select{onchange: 'location = this.value', style:'margin-top: 10px; margin-bottom: 10px', id: 'filter_by_procedure_select'}
     %option{value: backoffice_dossiers_path}

--- a/app/views/backoffice/dossiers/index.html.haml
+++ b/app/views/backoffice/dossiers/index.html.haml
@@ -1,7 +1,12 @@
 #backoffice_index
   #pref_list_menu
     = render partial: 'backoffice/dossiers/pref_list'
-  = render partial: 'backoffice/dossiers/onglets'
+
+  =link_to 'Tous mes dossiers en CSV', backoffice_download_dossiers_tps_path, {class: 'btn btn-success btn-sm', style: 'float: right; margin-right: 4%; margin-top: 7px'}
+  %h1 Gestion des dossiers
+
+  -unless Features.opensimplif
+    = render partial: 'backoffice/dossiers/onglets'
 
   = smart_listing_render :dossiers
 

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -31,7 +31,8 @@
     = render partial: 'administrateurs/login_banner'
   -else
     = link_to "Utilisateur", '/users/sign_in', method: :get, :class => 'btn btn-md'
-    = link_to "Accompagnateur", '/gestionnaires/sign_in', method: :get, :class => 'btn btn-md'
+    -unless Features.unified_login
+      = link_to "Accompagnateur", '/gestionnaires/sign_in', method: :get, :class => 'btn btn-md'
     = link_to "Administrateur", '/administrateurs/sign_in', method: :get, :class => 'btn btn-md'
 
 - if Rails.env != 'production'

--- a/app/views/users/dossiers/_onglets.html.haml
+++ b/app/views/users/dossiers/_onglets.html.haml
@@ -1,5 +1,3 @@
-%h1 Mes dossiers
-
 %br
 #onglets
   %ul.nav.nav-tabs

--- a/app/views/users/dossiers/index.html.haml
+++ b/app/views/users/dossiers/index.html.haml
@@ -1,5 +1,8 @@
 #users_index
-  = render partial: 'onglets'
+  %h1 Mes dossiers
+
+  -unless Features.opensimplif
+    = render partial: 'onglets'
 
   = smart_listing_render :dossiers
 

--- a/spec/controllers/admin/gestionnaires_controller_spec.rb
+++ b/spec/controllers/admin/gestionnaires_controller_spec.rb
@@ -147,6 +147,27 @@ describe Admin::GestionnairesController, type: :controller do
         }
       end
     end
+
+    context 'unified login' do
+      before do
+        allow(Features).to receive(:unified_login).and_return(true)
+        subject
+      end
+
+      it "creates associated user with same credentials" do
+        gestionnaire = controller.instance_variable_get(:@gestionnaire)
+        user = User.find_by(email: gestionnaire.email)
+        expect(user.valid_password?(gestionnaire.password)).to be(true)
+      end
+
+      context 'invalid email' do
+        let(:email) { 'fail' }
+
+        it "won't create associated user" do
+          expect(User.where(email: email).exists?).to be(false)
+        end
+      end
+    end
   end
 
   describe 'DELETE #destroy' do

--- a/spec/controllers/gestionnaires/passwords_controller_spec.rb
+++ b/spec/controllers/gestionnaires/passwords_controller_spec.rb
@@ -6,11 +6,12 @@ describe Gestionnaires::PasswordsController, type: :controller do
   end
 
   describe "update" do
-    context "when associated gestionnaire" do
+    context "unified login" do
       let(:gestionnaire) { create(:gestionnaire, email: 'unique@plop.com', password: 'password') }
       let(:user) { create(:user, email: 'unique@plop.com', password: 'password') }
 
       before do
+        allow(Features).to receive(:unified_login).and_return(true)
         @token = gestionnaire.send(:set_reset_password_token)
         user # make sure it's created
       end

--- a/spec/controllers/root_controller_spec.rb
+++ b/spec/controllers/root_controller_spec.rb
@@ -40,4 +40,18 @@ describe RootController, type: :controller do
 
     it { expect(response.body).to have_css('#landing') }
   end
+
+  context "unified login" do
+    render_views
+
+    before do
+      allow(Features).to receive(:unified_login).and_return(true)
+      subject
+    end
+
+    it "won't have gestionnaire login link" do
+      expect(response.body).to have_css("a[href='#{new_user_session_path}']")
+      expect(response.body).to_not have_css("a[href='#{new_gestionnaire_session_path}']")
+    end
+  end
 end

--- a/spec/controllers/users/passwords_controller_spec.rb
+++ b/spec/controllers/users/passwords_controller_spec.rb
@@ -6,11 +6,12 @@ describe Users::PasswordsController, type: :controller do
   end
 
   describe "update" do
-    context "when associated gestionnaire" do
+    context "unified login" do
       let(:user) { create(:user, email: 'unique@plop.com', password: 'password') }
       let(:gestionnaire) { create(:gestionnaire, email: 'unique@plop.com', password: 'password') }
 
       before do
+        allow(Features).to receive(:unified_login).and_return(true)
         @token = user.send(:set_reset_password_token)
         gestionnaire # make sure it's created
       end

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -34,9 +34,10 @@ describe Users::SessionsController, type: :controller do
       it { is_expected.to be_falsey }
     end
 
-    context "when associated gestionnaire" do
+    context "unified login" do
       let(:user) { create(:user, email: 'unique@plop.com', password: 'password') }
       let(:gestionnaire) { create(:gestionnaire, email: 'unique@plop.com', password: 'password') }
+      before { allow(Features).to receive(:unified_login).and_return(true) }
 
       it 'signs user in' do
         post :create, user: { email: user.email, password: user.password }

--- a/spec/features/backoffice/onglets_link_spec.rb
+++ b/spec/features/backoffice/onglets_link_spec.rb
@@ -89,4 +89,16 @@ feature 'on click on tabs button' do
       end
     end
   end
+
+  context "OpenSimplif" do
+    before do
+      allow(Features).to receive(:opensimplif).and_return(true)
+      visit backoffice_dossiers_url
+    end
+
+    scenario "it hides the tabs" do
+      expect(page).to_not have_css('#filter_by_procedure')
+      expect(page).to_not have_css('#onglets')
+    end
+  end
 end

--- a/spec/features/users/onglets_link_spec.rb
+++ b/spec/features/users/onglets_link_spec.rb
@@ -99,4 +99,15 @@ feature 'on click on tabs button' do
       end
     end
   end
+
+  context "OpenSimplif" do
+    before do
+      allow(Features).to receive(:opensimplif).and_return(true)
+      visit users_dossiers_url
+    end
+
+    scenario "it hides the tabs" do
+      expect(page).to_not have_css('#onglets')
+    end
+  end
 end

--- a/spec/models/gestionnaire_spec.rb
+++ b/spec/models/gestionnaire_spec.rb
@@ -185,14 +185,18 @@ describe Gestionnaire, type: :model do
     end
   end
 
-  it 'syncs credentials to associated user' do
-    gestionnaire = create(:gestionnaire)
-    user = create(:user, email: gestionnaire.email)
+  context 'unified login' do
+    before { allow(Features).to receive(:unified_login).and_return(true) }
 
-    gestionnaire.update_attributes(email: 'whoami@plop.com', password: 'super secret')
+    it 'syncs credentials to associated user' do
+      gestionnaire = create(:gestionnaire)
+      user = create(:user, email: gestionnaire.email)
 
-    user.reload
-    expect(user.email).to eq('whoami@plop.com')
-    expect(user.valid_password?('super secret')).to be(true)
+      gestionnaire.update_attributes(email: 'whoami@plop.com', password: 'super secret')
+
+      user.reload
+      expect(user.email).to eq('whoami@plop.com')
+      expect(user.valid_password?('super secret')).to be(true)
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -73,14 +73,18 @@ describe User, type: :model do
     end
   end
 
-  it 'syncs credentials to associated gestionnaire' do
-    user = create(:user)
-    gestionnaire = create(:gestionnaire, email: user.email)
+  context 'unified login' do
+    before { allow(Features).to receive(:unified_login).and_return(true) }
 
-    user.update_attributes(email: 'whoami@plop.com', password: 'super secret')
+    it 'syncs credentials to associated gestionnaire' do
+      user = create(:user)
+      gestionnaire = create(:gestionnaire, email: user.email)
 
-    gestionnaire.reload
-    expect(gestionnaire.email).to eq('whoami@plop.com')
-    expect(gestionnaire.valid_password?('super secret')).to be(true)
+      user.update_attributes(email: 'whoami@plop.com', password: 'super secret')
+
+      gestionnaire.reload
+      expect(gestionnaire.email).to eq('whoami@plop.com')
+      expect(gestionnaire.valid_password?('super secret')).to be(true)
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -83,6 +83,10 @@ class Features
   def self.unified_login
     false
   end
+
+  def self.opensimplif
+    false
+  end
 end
 
 WebMock.disable_net_connect!(allow_localhost: true)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -75,6 +75,16 @@ module SmartListing
   end
 end
 
+class Features
+  #def self.remote_storage
+  #  true
+  #end
+
+  def self.unified_login
+    false
+  end
+end
+
 WebMock.disable_net_connect!(allow_localhost: true)
 
 RSpec.configure do |config|


### PR DESCRIPTION
Introduces 2 new features:

1. `unified_login` for a user and a gestionnaire to share authentication (applied everywhere);
2. `opensimplif` for specifics (e.g. hide user/gestionnaire tabs).

Creates the user automatically when a gestionnaire is created by an admin.