### PR TITLE
Flux de commentaires par champs

### DIFF
--- a/app/assets/javascripts/dossier_commentaires_modal.js
+++ b/app/assets/javascripts/dossier_commentaires_modal.js
@@ -1,0 +1,13 @@
+$(document).ready(function () {
+  var modal = $("#modalCommentairesDossierParChamp");
+  var body = modal.find(".modal-body");
+  var originalBody = body.html();
+
+  modal.on("show.bs.modal", function (e) {
+    body.load(e.relatedTarget.getAttribute("data-href"));
+  });
+
+  $("#modalCommentairesDossierParChamp").on("hidden.bs.modal", function (e) {
+    body.html(originalBody);
+  });
+});

--- a/app/assets/javascripts/dossier_commentaires_modal.js
+++ b/app/assets/javascripts/dossier_commentaires_modal.js
@@ -1,13 +1,16 @@
-$(document).ready(function () {
-  var modal = $("#modalCommentairesDossierParChamp");
-  var body = modal.find(".modal-body");
-  var originalBody = body.html();
+$(document).on('page:load', init_modal_commentaire);
+$(document).ready(init_modal_commentaire);
 
-  modal.on("show.bs.modal", function (e) {
-    body.load(e.relatedTarget.getAttribute("data-href"));
-  });
+function init_modal_commentaire() {
+    var modal = $("#modalCommentairesDossierParChamp");
+    var body = modal.find(".modal-body");
+    var originalBody = body.html();
 
-  $("#modalCommentairesDossierParChamp").on("hidden.bs.modal", function (e) {
-    body.html(originalBody);
-  });
-});
+    modal.on("show.bs.modal", function (e) {
+        body.load(e.relatedTarget.getAttribute("data-href"));
+    });
+
+    $("#modalCommentairesDossierParChamp").on("hidden.bs.modal", function (e) {
+        body.html(originalBody);
+    });
+}

--- a/app/controllers/commentaires_controller.rb
+++ b/app/controllers/commentaires_controller.rb
@@ -1,7 +1,20 @@
 class CommentairesController < ApplicationController
+  def index
+    @facade = DossierFacades.new(
+      params[:dossier_id],
+      (current_gestionnaire || current_user).email,
+      params[:champs_id]
+    )
+    render layout: false
+  rescue ActiveRecord::RecordNotFound
+    flash.alert = t('errors.messages.dossier_not_found')
+    redirect_to url_for(controller: '/')
+  end
+
   def create
     @commentaire = Commentaire.new
     @commentaire.dossier = Dossier.find(params['dossier_id'])
+    @commentaire.champ = @commentaire.dossier.champs.find(params[:champ_id]) if params[:champ_id]
 
     if is_gestionnaire?
       @commentaire.email = current_gestionnaire.email

--- a/app/facades/dossier_facades.rb
+++ b/app/facades/dossier_facades.rb
@@ -32,11 +32,7 @@ class DossierFacades
   end
 
   def commentaires
-    if @champ_id
-      @dossier.ordered_commentaires.where(champ_id: @champ_id).decorate
-    else
-      @dossier.ordered_commentaires.all.decorate
-    end
+    @dossier.ordered_commentaires.where(champ_id: @champ_id).decorate
   end
 
   def commentaire_email

--- a/app/facades/dossier_facades.rb
+++ b/app/facades/dossier_facades.rb
@@ -1,9 +1,10 @@
 class DossierFacades
 
   #TODO rechercher en fonction de la personne/email
-  def initialize dossier_id, email
+  def initialize(dossier_id, email, champ_id = nil)
     @dossier = Dossier.where(archived: false).find(dossier_id)
     @email = email
+    @champ_id = champ_id
   end
 
   def dossier
@@ -26,8 +27,16 @@ class DossierFacades
     @dossier.ordered_pieces_justificatives
   end
 
+  def champ_id
+    @champ_id
+  end
+
   def commentaires
-    @dossier.ordered_commentaires.all.decorate
+    if @champ_id
+      @dossier.ordered_commentaires.where(champ_id: @champ_id).decorate
+    else
+      @dossier.ordered_commentaires.all.decorate
+    end
   end
 
   def commentaire_email

--- a/app/models/champ.rb
+++ b/app/models/champ.rb
@@ -1,6 +1,7 @@
 class Champ < ActiveRecord::Base
   belongs_to :dossier
   belongs_to :type_de_champ
+  has_many :commentaires
 
   delegate :libelle, :type_champ, :order_place, :mandatory, :description, :drop_down_list, to: :type_de_champ
 

--- a/app/models/commentaire.rb
+++ b/app/models/commentaire.rb
@@ -1,5 +1,6 @@
 class Commentaire < ActiveRecord::Base
   belongs_to :dossier
+  belongs_to :champ
 
   belongs_to :piece_justificative
 end

--- a/app/views/backoffice/commentaires/index.html.haml
+++ b/app/views/backoffice/commentaires/index.html.haml
@@ -1,0 +1,1 @@
+= render partial: '/users/recapitulatif/commentaires_flux'

--- a/app/views/dossiers/_infos_dossier.html.haml
+++ b/app/views/dossiers/_infos_dossier.html.haml
@@ -63,6 +63,12 @@
             %tr
               %th{ style: 'width:25%' }
                 =champ.libelle
+                -if gestionnaire_signed_in?
+                  =link_to "COM", "", "data-href" => backoffice_dossier_commentaires_path(@facade.dossier, champs_id: champ.id),
+                    "data-toggle" => "modal", "data-target" => "#modalCommentairesDossierParChamp"
+                -else
+                  =link_to "COM", "", "data-href" => users_dossier_commentaires_path(@facade.dossier, champs_id: champ.id),
+                    "data-toggle" => "modal", "data-target" => "#modalCommentairesDossierParChamp"
               %td
                 -unless champ.decorate.value.blank?
                   =champ.decorate.value.html_safe
@@ -114,3 +120,18 @@
           %button.action_button.btn.btn-warning
             %i.fa.fa-circle-o
 
+#modalCommentairesDossierParChamp.modal.fade{"tabindex" => -1, "role" => "dialog"}
+  .modal-dialog{"role" => "document"}
+    .modal-content
+      .modal-header
+        %button.close{"data-dismiss" => "modal", "aria-label" => "Fermer"}
+          %span{"aria-hidden" => true}
+            &times;
+        .modal-title
+          Commentaires
+      .modal-body
+        %p
+          Chargement des commentaires en cours...
+      .modal-footer
+        %button.btn.btn-primary{"data-dismiss" => "modal"}
+          Fermer

--- a/app/views/users/commentaires/index.html.haml
+++ b/app/views/users/commentaires/index.html.haml
@@ -1,0 +1,1 @@
+= render partial: '/users/recapitulatif/commentaires_flux'

--- a/app/views/users/recapitulatif/_commentaires_flux.html.haml
+++ b/app/views/users/recapitulatif/_commentaires_flux.html.haml
@@ -1,6 +1,6 @@
 .content#commentaires_flux{style:'width:100%;'}
   %div#commentaire_new{style: 'width:80%; margin-left:auto; margin-right:auto; margin-bottom:7%'}
-    = form_tag(url_for({ controller: 'commentaires', action: :create, dossier_id: @facade.dossier.id }), class: 'form-inline', method: 'POST', multipart: true) do
+    = form_tag(url_for({ controller: 'commentaires', action: :create, dossier_id: @facade.dossier.id, champ_id: @facade.champ_id }), class: 'form-inline', method: 'POST', multipart: true) do
       %textarea.form-control{id: 'texte_commentaire', class: 'wysihtml5', name: 'texte_commentaire', style: 'width: 100%; margin-bottom:2%', rows: '5', placeholder:"Commentaire"}
       %h4.text-primary{style: 'margin-top: 0px'} Ajout un fichier
       = file_field_tag "piece_justificative[content]", accept:  PieceJustificative.accept_format, style: 'float: left; margin-left: 20px'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,7 @@ Rails.application.routes.draw do
       post '/recapitulatif/submit' => 'recapitulatif#submit'
 
       post '/commentaire' => 'commentaires#create'
+      resources :commentaires, only: [:index]
 
       get '/carte/position' => 'carte#get_position'
       post '/carte/qp' => 'carte#get_qp'
@@ -162,6 +163,7 @@ Rails.application.routes.draw do
       post 'close' => 'dossiers#close'
 
       put 'follow' => 'dossiers#follow'
+      resources :commentaires, only: [:index]
     end
 
 

--- a/db/migrate/20161110082244_add_champ_id_to_commentaires.rb
+++ b/db/migrate/20161110082244_add_champ_id_to_commentaires.rb
@@ -1,0 +1,7 @@
+class AddChampIdToCommentaires < ActiveRecord::Migration
+  def change
+    change_table :commentaires do |t|
+      t.references :champ, null: true, index: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161102154835) do
+ActiveRecord::Schema.define(version: 20161110082244) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -112,8 +112,10 @@ ActiveRecord::Schema.define(version: 20161102154835) do
     t.integer  "dossier_id"
     t.datetime "updated_at",             null: false
     t.integer  "piece_justificative_id"
+    t.integer  "champ_id"
   end
 
+  add_index "commentaires", ["champ_id"], name: "index_commentaires_on_champ_id", using: :btree
   add_index "commentaires", ["dossier_id"], name: "index_commentaires_on_dossier_id", using: :btree
 
   create_table "dossiers", force: :cascade do |t|

--- a/spec/features/backoffice/flux_de_commentaires_spec.rb
+++ b/spec/features/backoffice/flux_de_commentaires_spec.rb
@@ -18,12 +18,12 @@ feature 'backoffice: flux de commentaires' do
     visit backoffice_dossier_path(dossier)
   end
 
-  scenario "tous les commentaires sont affichés" do
+  scenario "seuls les commentaires généraux sont affichés" do
     comments = find("#commentaires_flux")
-    expect(comments).to have_selector(".description", count: 4)
+    expect(comments).to have_selector(".description", count: 1)
   end
 
-  scenario "ouverture commentaires limités au champs dans une modale", js: true do
+  scenario "affichage des commentaires du champs", js: true do
     find("#liste_champs th", text: champ1.libelle).click_link("COM")
     expect(page).to have_css("#modalCommentairesDossierParChamp.in")
 
@@ -40,9 +40,9 @@ feature 'backoffice: flux de commentaires' do
     form.fill_in("texte_commentaire", with: "le corps du commentaire sur le champ #{champ1.libelle}")
     form.click_on("Poster")
 
-    # ajout du commentaire à la liste des commentaires
+    # le commentaire ne s'ajoute pas aux commentaires généraux
     comments = find("#commentaires_flux")
-    expect(comments).to have_selector(".description", count: 5)
+    expect(comments).to have_selector(".description", count: 1)
 
     # ajout du commentaire aux commentaires du champs
     find("#liste_champs th", text: champ1.libelle).click_link("COM")

--- a/spec/features/backoffice/flux_de_commentaires_spec.rb
+++ b/spec/features/backoffice/flux_de_commentaires_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+feature 'backoffice: flux de commentaires' do
+  let(:gestionnaire) { create(:gestionnaire) }
+  let(:dossier) { create(:dossier, :with_entreprise) }
+  let(:dossier_id) { dossier.id }
+
+  let(:champ1) { dossier.champs.first }
+  let(:champ2) { create(:champ, dossier: dossier, type_de_champ: create(:type_de_champ_public, libelle: "subtitle")) }
+
+  let!(:commentaire1) { create(:commentaire, dossier: dossier, champ: champ1) }
+  let!(:commentaire2) { create(:commentaire, dossier: dossier) }
+  let!(:commentaire3) { create(:commentaire, dossier: dossier, champ: champ2) }
+  let!(:commentaire4) { create(:commentaire, dossier: dossier, champ: champ1) }
+
+  before do
+    login_as gestionnaire, scope: :gestionnaire
+    visit backoffice_dossier_path(dossier)
+  end
+
+  scenario "tous les commentaires sont affichés" do
+    comments = find("#commentaires_flux")
+    expect(comments).to have_selector(".description", count: 4)
+  end
+
+  scenario "ouverture commentaires limités au champs dans une modale", js: true do
+    find("#liste_champs th", text: champ1.libelle).click_link("COM")
+    expect(page).to have_css("#modalCommentairesDossierParChamp.in")
+
+    modal = find("#modalCommentairesDossierParChamp")
+    expect(modal).to have_css(".description", count: 2)
+  end
+
+  scenario "crée un commentaire sur un champ", js: true do
+    # ouverture modale
+    find("#liste_champs th", text: champ1.libelle).click_link("COM")
+
+    # ajout du commentaire
+    form = find("#modalCommentairesDossierParChamp").find("#commentaire_new")
+    form.fill_in("texte_commentaire", with: "le corps du commentaire sur le champ #{champ1.libelle}")
+    form.click_on("Poster")
+
+    # ajout du commentaire à la liste des commentaires
+    comments = find("#commentaires_flux")
+    expect(comments).to have_selector(".description", count: 5)
+
+    # ajout du commentaire aux commentaires du champs
+    find("#liste_champs th", text: champ1.libelle).click_link("COM")
+    modal = find("#modalCommentairesDossierParChamp")
+    expect(modal).to have_css(".description", count: 3)
+  end
+end

--- a/spec/features/users/flux_de_commentaires_spec.rb
+++ b/spec/features/users/flux_de_commentaires_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+feature 'users: flux de commentaires' do
+  let(:user) { create(:user) }
+  let(:dossier) { create(:dossier, :with_entreprise, user: user, state: "replied") }
+  let(:dossier_id) { dossier.id }
+
+  let(:champ1) { dossier.champs.first }
+  let(:champ2) { create(:champ, dossier: dossier, type_de_champ: create(:type_de_champ_public, libelle: "subtitle")) }
+
+  let!(:commentaire1) { create(:commentaire, dossier: dossier, champ: champ1) }
+  let!(:commentaire2) { create(:commentaire, dossier: dossier) }
+  let!(:commentaire3) { create(:commentaire, dossier: dossier, champ: champ2) }
+  let!(:commentaire4) { create(:commentaire, dossier: dossier, champ: champ1) }
+
+  before do
+    login_as user, scope: :user
+    visit users_dossier_recapitulatif_path(dossier)
+  end
+
+  scenario "tous les commentaires sont affichés" do
+    comments = find("#commentaires_flux")
+    expect(comments).to have_selector(".description", count: 4)
+  end
+
+  scenario "ouverture commentaires limités au champs dans une modale", js: true do
+    th = find("#liste_champs th", text: champ1.libelle)
+    th.click_link("COM")
+    expect(page).to have_css("#modalCommentairesDossierParChamp.in")
+
+    modal = find("#modalCommentairesDossierParChamp")
+    expect(modal).to have_css(".description", count: 2)
+  end
+
+  scenario "crée un commentaire sur un champ", js: true do
+    # ouverture modale
+    find("#liste_champs th", text: champ1.libelle).click_link("COM")
+
+    # ajout du commentaire
+    form = find("#modalCommentairesDossierParChamp").find("#commentaire_new")
+    form.fill_in("texte_commentaire", with: "le corps du commentaire sur le champ #{champ1.libelle}")
+    form.click_on("Poster")
+
+    # ajout du commentaire à la liste des commentaires
+    comments = find("#commentaires_flux")
+    expect(comments).to have_selector(".description", count: 5)
+
+    # ajout du commentaire aux commentaires du champs
+    find("#liste_champs th", text: champ1.libelle).click_link("COM")
+    modal = find("#modalCommentairesDossierParChamp")
+    expect(modal).to have_css(".description", count: 3)
+  end
+end

--- a/spec/features/users/flux_de_commentaires_spec.rb
+++ b/spec/features/users/flux_de_commentaires_spec.rb
@@ -18,12 +18,12 @@ feature 'users: flux de commentaires' do
     visit users_dossier_recapitulatif_path(dossier)
   end
 
-  scenario "tous les commentaires sont affichés" do
+  scenario "seuls les commentaires généraux sont affichés" do
     comments = find("#commentaires_flux")
-    expect(comments).to have_selector(".description", count: 4)
+    expect(comments).to have_selector(".description", count: 1)
   end
 
-  scenario "ouverture commentaires limités au champs dans une modale", js: true do
+  scenario "affichage des commentaires du champs", js: true do
     th = find("#liste_champs th", text: champ1.libelle)
     th.click_link("COM")
     expect(page).to have_css("#modalCommentairesDossierParChamp.in")
@@ -41,9 +41,9 @@ feature 'users: flux de commentaires' do
     form.fill_in("texte_commentaire", with: "le corps du commentaire sur le champ #{champ1.libelle}")
     form.click_on("Poster")
 
-    # ajout du commentaire à la liste des commentaires
+    # le commentaire ne s'ajoute pas aux commentaires généraux
     comments = find("#commentaires_flux")
-    expect(comments).to have_selector(".description", count: 5)
+    expect(comments).to have_selector(".description", count: 1)
 
     # ajout du commentaire aux commentaires du champs
     find("#liste_champs th", text: champ1.libelle).click_link("COM")


### PR DESCRIPTION
Ajout d'un lien à côté des champs d'un dossier qui ouvre une modale contenant les commentaires liés à ce champs uniquement, avec un formulaire pour ajouter un commentaire lié à ce champs. Les commentaires continuent à tous être affichés sous le récapitulatif du dossier.

Techniquement, j'ai ajouté une colonne optionnelle `champ_id` à `commentaires` et les associations qui vont bien comme préconisé par @XjulI1.

Note : il manque une jolie icône au lieu du môche `COM` pour le lien à côté des champs.