### PR TITLE
Order types_de_piece_justificative on Procedure

### DIFF
--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -1,5 +1,5 @@
 class Procedure < ActiveRecord::Base
-  has_many :types_de_piece_justificative, dependent: :destroy
+  has_many :types_de_piece_justificative, -> { order "order_place ASC" }, dependent: :destroy
   has_many :types_de_champ, class_name: 'TypeDeChampPublic', dependent: :destroy
   has_many :types_de_champ_private, dependent: :destroy
   has_many :dossiers
@@ -64,10 +64,6 @@ class Procedure < ActiveRecord::Base
     types_de_champ_private.order(:order_place)
   end
 
-  def types_de_piece_justificative_ordered
-    types_de_piece_justificative.order(:order_place)
-  end
-
   def self.active id
     Procedure.where(archived: false, published: true).find(id)
   end
@@ -81,7 +77,7 @@ class Procedure < ActiveRecord::Base
   end
 
   def switch_types_de_piece_justificative index_of_first_element
-    switch_list_order(types_de_piece_justificative_ordered, index_of_first_element)
+    switch_list_order(types_de_piece_justificative, index_of_first_element)
   end
 
   def switch_list_order(list, index_of_first_element)

--- a/app/views/admin/pieces_justificatives/_form.html.haml
+++ b/app/views/admin/pieces_justificatives/_form.html.haml
@@ -1,6 +1,6 @@
 = form_for [:admin, @procedure], url: admin_procedure_pieces_justificatives_path(@procedure), remote: true do |f|
   #liste_piece_justificative
-    = render partial: 'fields', locals: { types_de_piece_justificative: @procedure.types_de_piece_justificative_ordered.decorate, f: f }
+    = render partial: 'fields', locals: { types_de_piece_justificative: @procedure.types_de_piece_justificative.decorate, f: f }
     = f.submit "Enregistrer", class: 'btn btn-success', id: :save
     %hr
   #new_type_de_piece_justificative

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -63,8 +63,8 @@ FactoryGirl.define do
 
     trait :with_two_type_de_piece_justificative do
       after(:build) do |procedure, _evaluator|
-        rib = create(:type_de_piece_justificative, :rib)
-        msa = create(:type_de_piece_justificative, :msa)
+        rib = create(:type_de_piece_justificative, :rib, order_place: 1)
+        msa = create(:type_de_piece_justificative, :msa, order_place: 2)
 
         procedure.types_de_piece_justificative << rib
         procedure.types_de_piece_justificative << msa


### PR DESCRIPTION
So that /spec/controllers/api/v1/
dossiers_controller_spec.rb#L163-L179 (on commit
8852431 for example) does not randomly fail due
to unordered types_de_piece_justificative