### PR TITLE
[Fix #137] Change the dossier link placeholder

### DIFF
--- a/app/views/users/description/champs/_dossier_link.html.haml
+++ b/app/views/users/description/champs/_dossier_link.html.haml
@@ -5,7 +5,7 @@
 
 .dossier-link
   %input.form-control{ name: "champs['#{ champ.id }']",
-                       placeholder: champ.libelle,
+                       placeholder: "Numéro de dossier",
                        id: "champs_#{ champ.id }",
                        value: champ.value,
                        type: 'number',

--- a/spec/views/users/description/champs/_dossier_link.html.haml_spec.rb
+++ b/spec/views/users/description/champs/_dossier_link.html.haml_spec.rb
@@ -11,7 +11,7 @@ describe 'users/description/champs/dossier_link.html.haml', type: :view do
     let!(:champ) { create(:champ, type_de_champ: type_champ, value: nil) }
 
     it 'should render an input for the dossier link' do
-      expect(rendered).to have_css("input[type=number][placeholder=#{champ.libelle}]")
+      expect(rendered).to have_css("input[type=number][placeholder='Numéro de dossier']")
     end
   end
 


### PR DESCRIPTION
Otherwise we don’t know what to enter (words,
numbers…)