### PR TITLE
[Fix #132] Show the dossier link in the dossier detail for Users

### DIFF
--- a/app/views/dossiers/_infos_dossier.html.haml
+++ b/app/views/dossiers/_infos_dossier.html.haml
@@ -40,10 +40,10 @@
               - unless champ.decorate.value.blank?
                 - if champ.type_champ == 'dossier_link'
                   - dossier = Dossier.includes(:procedure).find_by(id: champ.decorate.value)
-                  - if dossier && gestionnaire_signed_in?
+                  - if dossier
                     = link_to(dossier.procedure.libelle, backoffice_dossier_path(champ.decorate.value), target: '_blank')
                   - else
-                    = dossier.nil? ? 'pas de dossier associé' : dossier.procedure.libelle
+                    Pas de dossier associé
                 - else
                   = champ.decorate.value.html_safe
 

--- a/spec/features/users/dossier_edition_spec.rb
+++ b/spec/features/users/dossier_edition_spec.rb
@@ -38,7 +38,7 @@ feature 'As a User I want to edit a dossier I own' do
       # Linked Dossier
       linked_dossier_id = dossier.champs.find { |c| c.type_de_champ.type_champ == 'dossier_link' }.value
       linked_dossier = Dossier.find(linked_dossier_id)
-      expect(page).to have_content(linked_dossier.procedure.libelle)
+      expect(page).to have_link(linked_dossier.procedure.libelle)
 
       page.find_by_id('maj_infos').trigger('click')
       expect(page).to have_current_path(users_dossier_description_path(dossier.id.to_s), only_path: true)


### PR DESCRIPTION
There’s no reason why they couldn’t easily
navigate to it

Also improve the typography of a placeholder
message