### PR TITLE
[Fix #198] Add a Commentaire when we send a Notification email to a user

### DIFF
--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -1,13 +1,15 @@
 class NotificationMailer < ApplicationMailer
   default to: Proc.new { @user.email }
 
+  after_action :create_commentaire_for_notification, only: :send_notification
+
   def send_notification dossier, mail_template
     vars_mailer(dossier)
 
-    obj  = mail_template.object_for_dossier dossier
-    body = mail_template.body_for_dossier dossier
+    @obj  = mail_template.object_for_dossier dossier
+    @body = mail_template.body_for_dossier dossier
 
-    mail(subject: obj) { |format| format.html { body } }
+    mail(subject: @obj) { |format| format.html { @body } }
   end
 
   def new_answer dossier
@@ -15,6 +17,14 @@ class NotificationMailer < ApplicationMailer
   end
 
   private
+
+  def create_commentaire_for_notification
+    Commentaire.create(
+      dossier: @dossier,
+      email: "contact@tps.apientreprise.fr",
+      body: ["[#{@obj}]", @body].join("<br><br>")
+    )
+  end
 
   def vars_mailer dossier
     @dossier = dossier

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -5,10 +5,23 @@ RSpec.describe NotificationMailer, type: :mailer do
     let(:user) { create(:user) }
     let(:dossier) { create(:dossier, user: user) }
     let(:email) { instance_double('email', object_for_dossier: 'object', body_for_dossier: 'body') }
+    let (:notifications_count_before) { Notification.count }
     subject { described_class.send_notification(dossier, email) }
 
     it { expect(subject.subject).to eq(email.object_for_dossier) }
     it { expect(subject.body).to eq(email.body_for_dossier) }
+
+    it "creates a commentaire, which is not notified" do
+      described_class.send_notification(dossier, email).deliver_now
+
+      commentaire = Commentaire.last
+      notifications_count_after = Notification.count
+
+      expect(commentaire.dossier).to eq(dossier)
+      expect(commentaire.email).to eq("contact@tps.apientreprise.fr")
+      expect(commentaire.body).to eq("[object]<br><br>body")
+      expect(notifications_count_before).to eq(notifications_count_after)
+    end
   end
 
   describe ".new_answer" do


### PR DESCRIPTION
Waiting on #279 to merge