### PR TITLE
[Fix #323] Send notification emails when a dossier is automatically received

### DIFF
--- a/app/controllers/backoffice/dossiers_controller.rb
+++ b/app/controllers/backoffice/dossiers_controller.rb
@@ -99,8 +99,6 @@ class Backoffice::DossiersController < Backoffice::DossiersListController
     dossier.received!
     flash.notice = 'Dossier considéré comme reçu.'
 
-    NotificationMailer.send_notification(dossier, dossier.procedure.received_mail_template).deliver_now!
-
     redirect_to backoffice_dossier_path(id: dossier.id)
   end
 

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -78,6 +78,7 @@ class Dossier < ActiveRecord::Base
 
   after_save :build_default_champs, if: Proc.new { procedure_id_changed? }
   after_save :build_default_individual, if: Proc.new { procedure.for_individual? }
+  after_save :send_notification_email
 
   validates :user, presence: true
 
@@ -301,5 +302,11 @@ class Dossier < ActiveRecord::Base
 
   def serialize_value_for_export(value)
     value.nil? || value.kind_of?(Time) ? value : value.to_s
+  end
+
+  def send_notification_email
+    if state_changed? && EN_INSTRUCTION.include?(state)
+      NotificationMailer.send_notification(self, procedure.received_mail_template).deliver_now!
+    end
   end
 end

--- a/app/workers/auto_archive_procedure_worker.rb
+++ b/app/workers/auto_archive_procedure_worker.rb
@@ -2,12 +2,10 @@ class AutoArchiveProcedureWorker
   include Sidekiq::Worker
 
   def perform(*args)
-    procedures_to_archive = Procedure.not_archived.where("auto_archive_on <= ?", Date.today)
+    Procedure.not_archived.where("auto_archive_on <= ?", Date.today).each do |procedure|
+      procedure.dossiers.state_en_construction.update_all(state: :received)
 
-    procedures_to_archive.each do |p|
-      p.dossiers.state_en_construction.update_all(state: :received)
+      procedure.update_attributes!(archived: true)
     end
-
-    procedures_to_archive.update_all(archived: true)
   end
 end

--- a/app/workers/auto_archive_procedure_worker.rb
+++ b/app/workers/auto_archive_procedure_worker.rb
@@ -9,6 +9,5 @@ class AutoArchiveProcedureWorker
     end
 
     procedures_to_archive.update_all(archived: true)
-
   end
 end

--- a/app/workers/auto_archive_procedure_worker.rb
+++ b/app/workers/auto_archive_procedure_worker.rb
@@ -3,7 +3,9 @@ class AutoArchiveProcedureWorker
 
   def perform(*args)
     Procedure.not_archived.where("auto_archive_on <= ?", Date.today).each do |procedure|
-      procedure.dossiers.state_en_construction.update_all(state: :received)
+      procedure.dossiers.state_en_construction.each do |dossier|
+        dossier.received!
+      end
 
       procedure.update_attributes!(archived: true)
     end

--- a/app/workers/auto_archive_procedure_worker.rb
+++ b/app/workers/auto_archive_procedure_worker.rb
@@ -8,7 +8,7 @@ class AutoArchiveProcedureWorker
       p.dossiers.state_en_construction.update_all(state: :received)
     end
 
-    procedures_to_archive.update_all(archived: true, auto_archive_on: nil)
+    procedures_to_archive.update_all(archived: true)
 
   end
 end

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -867,4 +867,27 @@ describe Dossier do
     it { is_expected.to include(dossier3)}
     it { is_expected.to include(dossier4)}
   end
+
+  describe "#send_notification_email" do
+    let(:procedure) { create(:procedure) }
+    let(:dossier) { create(:dossier, procedure: procedure, state: :initiated) }
+
+    before do
+      ActionMailer::Base.deliveries.clear
+    end
+
+    it "sends an email when the dossier becomes received" do
+      dossier.received!
+
+      mail = ActionMailer::Base.deliveries.last
+
+      expect(mail.subject).to eq("Votre dossier TPS nº #{dossier.id} va être instruit")
+    end
+
+    it "does not an email when the dossier becomes closed" do
+      dossier.closed!
+
+      expect(ActionMailer::Base.deliveries.size).to eq(0)
+    end
+  end
 end

--- a/spec/workers/auto_archive_procedure_worker_spec.rb
+++ b/spec/workers/auto_archive_procedure_worker_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe AutoArchiveProcedureWorker, type: :worker do
-
   let!(:procedure) { create(:procedure, archived: false, auto_archive_on: nil )}
   let!(:procedure_hier) { create(:procedure, archived: false, auto_archive_on: 1.day.ago )}
   let!(:procedure_aujourdhui) { create(:procedure, archived: false, auto_archive_on: Date.today )}
@@ -17,11 +16,9 @@ RSpec.describe AutoArchiveProcedureWorker, type: :worker do
     end
 
     it { expect(procedure.archived).to eq false }
-
   end
 
   context "when procedures have auto_archive_on set on yesterday or today" do
-
     describe "titi" do
       before do
         subject
@@ -31,12 +28,9 @@ RSpec.describe AutoArchiveProcedureWorker, type: :worker do
 
       it { expect(procedure_hier.archived).to eq true }
       it { expect(procedure_aujourdhui.archived).to eq true }
-
     end
 
-
     context "with dossiers" do
-
       let!(:dossier1) { create(:dossier, procedure: procedure_hier, state: 'draft', archived: false)}
       let!(:dossier2) { create(:dossier, procedure: procedure_hier, state: 'initiated', archived: false)}
       let!(:dossier3) { create(:dossier, procedure: procedure_hier, state: 'replied', archived: false)}
@@ -61,18 +55,14 @@ RSpec.describe AutoArchiveProcedureWorker, type: :worker do
       it { expect(dossier6.state).to eq 'closed' }
       it { expect(dossier7.state).to eq 'refused' }
       it { expect(dossier8.state).to eq 'without_continuation' }
-
     end
   end
 
   context "when procedures have auto_archive_on set on future" do
-
     before do
       subject
     end
 
     it { expect(procedure_demain.archived).to eq false }
-
   end
-
 end


### PR DESCRIPTION
- [x] Depends on #360 

Après prod, il faut essayer de retrouver les procédures qui avaient une fermeture automatique et re-rempir la donnée qu'on a effacé.

Brouillon pour la détection de ces procédures :

```ruby
ar = []
Procedure.where(archived: true, created_at: "2017-3-15".to_date..Time.now).each do |procedure|
  STATES = [
    "received",
    "closed",
    "refused",
    "without_continuation"
  ]

  if procedure.dossiers.all? { |d| STATES.include?(d) }
    ar << procedure.id
  end
end
```