### PR TITLE
Fix bug on admin sign out

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -1,15 +1,6 @@
 class RootController < ApplicationController
   def index
-    begin
-      route = Rails.application.routes.recognize_path(request.referrer)
-    rescue ActionController::RoutingError
-      route = Rails.application.routes.recognize_path(new_user_session_path)
-    end
-
-    if user_signed_in? && !route[:controller].match('users').nil?
-      return redirect_to users_dossiers_path
-
-    elsif administrateur_signed_in? && !route[:controller].match('admin').nil?
+    if administrateur_signed_in?
       return redirect_to admin_procedures_path
 
     elsif gestionnaire_signed_in?
@@ -30,9 +21,6 @@ class RootController < ApplicationController
 
     elsif user_signed_in?
       return redirect_to users_dossiers_path
-
-    elsif administrateur_signed_in?
-      return redirect_to admin_procedures_path
 
     elsif administration_signed_in?
       return redirect_to administrations_path

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -38,8 +38,6 @@ class RootController < ApplicationController
       return redirect_to administrations_path
     end
 
-    @demo_environment_host = "https://tps-dev.apientreprise.fr" unless Rails.env.development?
-
     render 'landing', :layout => 'new_application'
   end
 end

--- a/spec/controllers/root_controller_spec.rb
+++ b/spec/controllers/root_controller_spec.rb
@@ -45,6 +45,14 @@ describe RootController, type: :controller do
     it { expect(subject).to redirect_to(admin_procedures_path) }
   end
 
+  context 'when Administration is connected' do
+    before do
+      sign_in create(:administration)
+    end
+
+    it { expect(subject).to redirect_to(administrations_path) }
+  end
+
   context 'when nobody is connected' do
     render_views
 


### PR DESCRIPTION
side effect, relevé après plusieurs tests : lorsqu'un utilisateur est connecté en multi profil gestionnaire/user, sur la vue user, s'il clique sur la marianne, il est redirigé sur le backoffice gestionnaire.

Je pense que c'est un cas ultra spécifique, et qu'on peut laisser comme tel, surtout que coté user on a rajouté un bouton "retourner aux dossiers".

WDYT ?