### PR TITLE
Fix cache bug on stats page

### DIFF
--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -18,8 +18,13 @@ class StatsController < ApplicationController
 
     @procedures_count_per_administrateur = procedures_count_per_administrateur(procedures)
 
-    @dossier_instruction_mean_time = dossier_instruction_mean_time(dossiers)
-    @dossier_filling_mean_time = dossier_filling_mean_time(dossiers)
+    @dossier_instruction_mean_time = Rails.cache.fetch("dossier_instruction_mean_time", expires_in: 1.day) do
+      dossier_instruction_mean_time(dossiers)
+    end
+
+    @dossier_filling_mean_time = Rails.cache.fetch("dossier_filling_mean_time", expires_in: 1.day) do
+      dossier_filling_mean_time(dossiers)
+    end
 
     @avis_usage = avis_usage
     @avis_average_answer_time = avis_average_answer_time

--- a/app/views/stats/index.html.haml
+++ b/app/views/stats/index.html.haml
@@ -57,24 +57,23 @@
             :colors => ["rgba(191, 220, 249, 1)", "rgba(113, 176, 239, 1)", "rgba(61, 149, 236, 1)"]
 
     - if administration_signed_in?
-      - cache "computation-heavy-stats", :expires_in => 1.day do
-        .stat-card.stat-card-half.pull-left
-          %span.stat-card-title Temps de traitement moyen d'un dossier
+      .stat-card.stat-card-half.pull-left
+        %span.stat-card-title Temps de traitement moyen d'un dossier
 
-          .chart-container
-            .chart
-              = line_chart @dossier_instruction_mean_time,
-                :ytitle => "Jours",
-                :colors => ["rgba(61, 149, 236, 1)"]
+        .chart-container
+          .chart
+            = line_chart @dossier_instruction_mean_time,
+              :ytitle => "Jours",
+              :colors => ["rgba(61, 149, 236, 1)"]
 
-        .stat-card.stat-card-half.pull-left
-          %span.stat-card-title Temps de remplissage moyen d'un dossier
+      .stat-card.stat-card-half.pull-left
+        %span.stat-card-title Temps de remplissage moyen d'un dossier
 
-          .chart-container
-            .chart
-              = line_chart @dossier_filling_mean_time,
-                :ytitle => "Minutes",
-                :colors => ["rgba(61, 149, 236, 1)"]
+        .chart-container
+          .chart
+            = line_chart @dossier_filling_mean_time,
+              :ytitle => "Minutes",
+              :colors => ["rgba(61, 149, 236, 1)"]
 
     .clearfix
 
@@ -92,6 +91,6 @@
 
       .stat-card.stat-card-half.pull-left
         %span.stat-card-title Pourcentage d'avis rempli
-        = line_chart @avis_answer_percentages, ytitle: 'avis avec reponse / total avis', xtitle: 'semaines'
+        = line_chart @avis_answer_percentages, ytitle: 'avis avec réponse / total avis', xtitle: 'semaines'
 
       .clearfix


### PR DESCRIPTION
Le problème vient du fait que l'on met en cache la partie de la vue rendue par chartkick.
Au premier chargement de la page, tout fonctionne normalement, les charts sont générés avec les id suivants : 
- chart-1
- chart-2 (mis en cache)
- chart-3

Au second chargement, charkick ne génère que deux graphes (le premier et le dernier), celui du milieu est récupéré du cache, il y a alors une collision d'id :
- chart-1
- chart-2 (récupéré du cache)
- chart-2