### PR TITLE
Track ask demo click on home page

### DIFF
--- a/app/views/layouts/_google_analytics.html.haml
+++ b/app/views/layouts/_google_analytics.html.haml
@@ -1,0 +1,9 @@
+- ua_id = Rails.env.production? ? 'UA-63927236-2' : 'UA-63927236-4'
+:javascript
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+  ga('create', '#{ua_id}', 'auto');
+  ga('send', 'pageview');

--- a/app/views/root/landing.html.haml
+++ b/app/views/root/landing.html.haml
@@ -10,7 +10,8 @@
 
           = link_to "Demander une démo",
             "mailto:#{t("dynamics.contact_email")}?subject=Demande de démo TPS",
-            :class => "hero-button"
+            class: "hero-button",
+            onclick: "javascript: ga('send', 'pageview', '/demander-une-demo')"
 
           %p.hero-phone-cta
             ou nous appeler au 01 40 15 68 49
@@ -132,6 +133,7 @@
         %div
           = link_to "Demander une démo",
             "mailto:#{t('dynamics.contact_email')}?subject=Demande de démo TPS",
-            :class => "cta-panel-button"
+            class: "cta-panel-button",
+            onclick: "javascript: ga('send', 'pageview', '/demander-une-demo')"
           %p.cta-panel-phone-cta
             ou nous appeler au 01 40 15 68 49

--- a/app/views/root/landing.html.haml
+++ b/app/views/root/landing.html.haml
@@ -11,6 +11,7 @@
           = link_to "Demander une démo",
             "mailto:#{t("dynamics.contact_email")}?subject=Demande de démo TPS",
             class: "hero-button",
+            target: "_blank",
             onclick: "javascript: ga('send', 'pageview', '/demander-une-demo')"
 
           %p.hero-phone-cta
@@ -134,6 +135,7 @@
           = link_to "Demander une démo",
             "mailto:#{t('dynamics.contact_email')}?subject=Demande de démo TPS",
             class: "cta-panel-button",
+            target: "_blank",
             onclick: "javascript: ga('send', 'pageview', '/demander-une-demo')"
           %p.cta-panel-phone-cta
             ou nous appeler au 01 40 15 68 49

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -69,7 +69,6 @@ set :shared_paths, [
                      'config/france_connect.yml',
                      'config/initializers/mailjet.rb',
                      'config/initializers/storage_url.rb',
-                     'app/views/layouts/_google_analytics.html',
                      'app/views/cgu/index.html.haml'
                  ]
 


### PR DESCRIPTION
Le but est de traquer le taux de conversion du bouton "Demander une démo", pour ensuite l'améliorer (cf. GDrive).

- [x] Depends on #391