### PR TITLE
In Avis sign up, fix the numero character and add a non-breaking space

### DIFF
--- a/app/views/backoffice/avis/sign_up.html.haml
+++ b/app/views/backoffice/avis/sign_up.html.haml
@@ -1,7 +1,7 @@
 .avis-sign-up
   .left
     %p.description= @dossier.procedure.libelle
-    %p.dossier Dossier n°#{@dossier.id}
+    %p.dossier Dossier nº #{@dossier.id}
   .right
     %h1 Créez-vous un compte
 


### PR DESCRIPTION
Conformément aux [règles typographiques](https://github.com/sgmap/tps/wiki/Typographie#abr%C3%A9viations)