### PR TITLE
474 display devise errors with flashes

### DIFF
--- a/app/controllers/backoffice/avis_controller.rb
+++ b/app/controllers/backoffice/avis_controller.rb
@@ -49,7 +49,7 @@ class Backoffice::AvisController < ApplicationController
       avis = Avis.find(params[:id])
       redirect_to url_for(backoffice_dossier_path(avis.dossier_id))
     else
-      flash[:alert] = gestionnaire.errors.full_messages.join('<br>')
+      flash[:alert] = gestionnaire.errors.full_messages
       redirect_to url_for(avis_sign_up_path(params[:id], email))
     end
   end

--- a/app/controllers/backoffice/private_formulaires_controller.rb
+++ b/app/controllers/backoffice/private_formulaires_controller.rb
@@ -11,7 +11,7 @@ class Backoffice::PrivateFormulairesController < ApplicationController
       if champs_service_errors.empty?
         flash[:notice] = "Formulaire enregistré"
       else
-        flash[:alert] = champs_service_errors.join('<br>').html_safe
+        flash[:alert] = champs_service_errors
       end
     end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,0 +1,8 @@
+module ApplicationHelper
+  def flash_class(level)
+    case level
+    when "notice" then "alert-success"
+    when "alert" then "alert-danger"
+    end
+  end
+end

--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -1,0 +1,8 @@
+module DeviseHelper
+  def devise_error_messages!
+    if resource.errors.full_messages.any?
+      flash.now[:alert] = resource.errors.full_messages
+    end
+    ''
+  end
+end

--- a/app/views/layouts/_flash_messages.html.haml
+++ b/app/views/layouts/_flash_messages.html.haml
@@ -1,8 +1,11 @@
-- if flash.notice.present? || flash.alert.present?
+- if flash.any?
   #flash_message.center
-    - if flash.notice.present?
-      .alert.alert-success
-        = flash.notice
-    - if flash.alert.present?
-      .alert.alert-danger
-        = flash.alert.html_safe
+    - flash.each do |key, value|
+      - if value.class == Array
+        .alert{ class: flash_class(key) }
+          - value.each do |message|
+            = message
+            %br
+      - else
+        .alert{ class: flash_class(key) }
+          = value

--- a/spec/controllers/backoffice/avis_controller_spec.rb
+++ b/spec/controllers/backoffice/avis_controller_spec.rb
@@ -178,7 +178,7 @@ describe Backoffice::AvisController, type: :controller do
 
         it { expect(created_gestionnaire).to be_nil }
         it { is_expected.to redirect_to avis_sign_up_path(avis_id, invited_email) }
-        it { expect(flash.alert).to eq('Password : Le mot de passe est vide') }
+        it { expect(flash.alert).to eq(['Password : Le mot de passe est vide']) }
       end
     end
   end


### PR DESCRIPTION
Inspiré de 
https://github.com/plataformatec/devise/wiki/Override-devise_error_messages!-for-views
et 
https://stackoverflow.com/questions/28963891/replace-devise-error-messages-with-flash-messages