### PR TITLE
Add inline address to etablissement

### DIFF
--- a/app/models/attestation_template.rb
+++ b/app/models/attestation_template.rb
@@ -75,7 +75,7 @@ class AttestationTemplate < ApplicationRecord
   end
 
   def etablissement_tags
-    [{ libelle: 'adresse', description: '', target: 'adresse' }]
+    [{ libelle: 'adresse', description: '', target: 'inline_adresse' }]
   end
 
   def build_pdf(dossier)

--- a/app/models/etablissement.rb
+++ b/app/models/etablissement.rb
@@ -9,4 +9,9 @@ class Etablissement < ActiveRecord::Base
   def geo_adresse
     [numero_voie, type_voie, nom_voie, complement_adresse, code_postal, localite].join(' ')
   end
+
+  def inline_adresse
+    #squeeze needed because of space in excess in the data
+    "#{numero_voie} #{type_voie} #{nom_voie}, #{complement_adresse}, #{code_postal} #{localite}".squeeze(' ')
+  end
 end

--- a/spec/models/attestation_template_spec.rb
+++ b/spec/models/attestation_template_spec.rb
@@ -159,7 +159,7 @@ describe AttestationTemplate, type: :model do
           let(:etablissement) { create(:etablissement, adresse: 'adresse') }
           let(:template_title) { '--adresse--' }
 
-          it { expect(view_args[:title]).to eq('adresse') }
+          it { expect(view_args[:title]).to eq(etablissement.inline_adresse) }
         end
       end
     end

--- a/spec/models/etablissement_spec.rb
+++ b/spec/models/etablissement_spec.rb
@@ -29,4 +29,10 @@ describe Etablissement do
 
     it { is_expected.to eq '6 RUE RAOUL NORDLING IMMEUBLE BORA 92270 BOIS COLOMBES' }
   end
+
+  describe '#inline_adresse' do
+    let(:etablissement) { create(:etablissement, nom_voie: 'green    moon') }
+
+    it { expect(etablissement.inline_adresse).to eq '6 RUE green moon, IMMEUBLE BORA, 92270 BOIS COLOMBES' }
+  end
 end


### PR DESCRIPTION
Permet d'enlever les retours à la ligne présents dans les adresses des attestations.