### PR TITLE
Procedure timestamps

### DIFF
--- a/app/controllers/admin/procedures_controller.rb
+++ b/app/controllers/admin/procedures_controller.rb
@@ -191,7 +191,7 @@ class Admin::ProceduresController < AdminController
     render json: ProcedurePath
                      .joins(', procedures')
                      .where("procedures.id = procedure_paths.procedure_id")
-                     .where("procedures.archived" => false)
+                     .where("procedures.archived_at" => nil)
                      .where("path LIKE '%#{params[:request]}%'")
                      .pluck(:path, :administrateur_id)
                      .inject([]) {

--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -285,7 +285,7 @@ class Dossier < ActiveRecord::Base
   end
 
   def can_be_initiated?
-    !(procedure.archived && draft?)
+    !(procedure.archived? && draft?)
   end
 
   def text_summary

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -34,8 +34,8 @@ class Procedure < ActiveRecord::Base
   default_scope { where(hidden_at: nil) }
   scope :published, -> { where.not(published_at: nil) }
   scope :not_published, -> { where(published_at: nil) }
-  scope :archived, -> { where(archived: true) }
-  scope :not_archived, -> { where(archived: false) }
+  scope :archived, -> { where.not(archived_at: nil) }
+  scope :not_archived, -> { where(archived_at: nil) }
   scope :by_libelle, -> { order(libelle: :asc) }
 
   validates :libelle, presence: true, allow_blank: false, allow_nil: false
@@ -106,7 +106,7 @@ class Procedure < ActiveRecord::Base
         types_de_champ: :drop_down_list,
         types_de_champ_private: :drop_down_list
       })
-    procedure.archived = false
+    procedure.archived_at = nil
     procedure.published_at = nil
     procedure.logo_secure_token = nil
     procedure.remote_logo_url = self.logo_url
@@ -121,7 +121,7 @@ class Procedure < ActiveRecord::Base
   end
 
   def publish!(path)
-    self.update_attributes!({ published_at: Time.now, archived: false })
+    self.update_attributes!({ published_at: Time.now, archived_at: nil })
     ProcedurePath.create!(path: path, procedure: self, administrateur: self.administrateur)
   end
 
@@ -131,7 +131,12 @@ class Procedure < ActiveRecord::Base
   end
 
   def archive
-    self.update_attributes!(archived: true, archived_at: Time.now)
+    self.update_attributes!(archived_at: Time.now)
+  end
+
+  # FIXME: remove once the archived colummn has been deleted
+  def archived?
+    archived_at.present?
   end
 
   def total_dossier

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -32,8 +32,8 @@ class Procedure < ActiveRecord::Base
   mount_uploader :logo, ProcedureLogoUploader
 
   default_scope { where(hidden_at: nil) }
-  scope :published, -> { where(published: true) }
-  scope :not_published, -> { where(published: false) }
+  scope :published, -> { where.not(published_at: nil) }
+  scope :not_published, -> { where(published_at: nil) }
   scope :archived, -> { where(archived: true) }
   scope :not_archived, -> { where(archived: false) }
   scope :by_libelle, -> { order(libelle: :asc) }
@@ -107,7 +107,7 @@ class Procedure < ActiveRecord::Base
         types_de_champ_private: :drop_down_list
       })
     procedure.archived = false
-    procedure.published = false
+    procedure.published_at = nil
     procedure.logo_secure_token = nil
     procedure.remote_logo_url = self.logo_url
 
@@ -121,8 +121,13 @@ class Procedure < ActiveRecord::Base
   end
 
   def publish!(path)
-    self.update_attributes!({ published: true, archived: false, published_at: Time.now })
+    self.update_attributes!({ published_at: Time.now, archived: false })
     ProcedurePath.create!(path: path, procedure: self, administrateur: self.administrateur)
+  end
+
+  # FIXME: remove once the published colummn has been deleted
+  def published?
+    published_at.present?
   end
 
   def archive

--- a/app/serializers/procedure_serializer.rb
+++ b/app/serializers/procedure_serializer.rb
@@ -6,7 +6,7 @@ class ProcedureSerializer < ActiveModel::Serializer
     :description,
     :organisation,
     :direction,
-    :archived,
+    :archived_at,
     :geographic_information,
     :total_dossier
 

--- a/doc/apipie_examples.json
+++ b/doc/apipie_examples.json
@@ -152,7 +152,7 @@
           "description": "Demande de subvention à l'intention des associations",
           "organisation": "Orga SGMAP",
           "direction": "direction SGMAP",
-          "archived": false,
+          "archived_at": null,
           "geographic_information": {
             "use_api_carto": false,
             "quartiers_prioritaires": false,

--- a/spec/controllers/admin/pieces_justificatives_controller_spec.rb
+++ b/spec/controllers/admin/pieces_justificatives_controller_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 describe Admin::PiecesJustificativesController, type: :controller do
   let(:admin) { create(:administrateur) }
-  let(:published) { false }
-  let(:procedure) { create(:procedure, administrateur: admin, published: published) }
+  let(:published_at) { nil }
+  let(:procedure) { create(:procedure, administrateur: admin, published_at: published_at) }
   before do
     sign_in admin
   end
@@ -19,7 +19,7 @@ describe Admin::PiecesJustificativesController, type: :controller do
     end
 
     context 'when procedure is published' do
-      let(:published) { true }
+      let(:published_at) { Time.now }
       it { is_expected.to redirect_to admin_procedure_path id: procedure_id }
     end
 

--- a/spec/controllers/admin/procedures_controller_spec.rb
+++ b/spec/controllers/admin/procedures_controller_spec.rb
@@ -54,9 +54,9 @@ describe Admin::ProceduresController, type: :controller do
   end
 
   describe 'DELETE #destroy' do
-    let(:procedure_draft) { create :procedure, published_at: nil, archived: false }
-    let(:procedure_published) { create :procedure, published_at: Time.now, archived: false }
-    let(:procedure_archived) { create :procedure, published_at: nil, archived: true }
+    let(:procedure_draft) { create :procedure, published_at: nil, archived_at: nil }
+    let(:procedure_published) { create :procedure, published_at: Time.now, archived_at: nil }
+    let(:procedure_archived) { create :procedure, published_at: nil, archived_at: Time.now }
 
     subject { delete :destroy, params: {id: procedure.id} }
 
@@ -316,7 +316,7 @@ describe Admin::ProceduresController, type: :controller do
 
         it 'archive previous procedure' do
           expect(procedure2.published?).to be_truthy
-          expect(procedure2.archived).to be_truthy
+          expect(procedure2.archived?).to be_truthy
           expect(procedure2.path).to be_nil
         end
       end
@@ -332,7 +332,7 @@ describe Admin::ProceduresController, type: :controller do
 
         it 'previous procedure remains published' do
           expect(procedure2.published?).to be_truthy
-          expect(procedure2.archived).to be_falsey
+          expect(procedure2.archived?).to be_falsey
           expect(procedure2.path).to match(/fake_path/)
         end
       end
@@ -377,7 +377,7 @@ describe Admin::ProceduresController, type: :controller do
       end
 
       context 'when owner want archive procedure' do
-        it { expect(procedure.archived).to be_truthy }
+        it { expect(procedure.archived?).to be_truthy }
         it { expect(response).to redirect_to :admin_procedures }
         it { expect(flash[:notice]).to have_content 'Procédure archivée' }
       end
@@ -388,7 +388,7 @@ describe Admin::ProceduresController, type: :controller do
           procedure.reload
         end
 
-        it { expect(procedure.archived).to be_falsey }
+        it { expect(procedure.archived?).to be_falsey }
         it { expect(response.status).to eq 200 }
         it { expect(flash[:notice]).to have_content 'Procédure publiée' }
       end
@@ -479,7 +479,7 @@ describe Admin::ProceduresController, type: :controller do
 
     context 'when procedure is archived' do
       before do
-        procedure3.update_attribute :archived, true
+        procedure3.update_attribute :archived_at, Time.now
         subject
       end
 

--- a/spec/controllers/admin/procedures_controller_spec.rb
+++ b/spec/controllers/admin/procedures_controller_spec.rb
@@ -54,9 +54,9 @@ describe Admin::ProceduresController, type: :controller do
   end
 
   describe 'DELETE #destroy' do
-    let(:procedure_draft) { create :procedure, published: false, archived: false }
-    let(:procedure_published) { create :procedure, published: true, archived: false }
-    let(:procedure_archived) { create :procedure, published: false, archived: true }
+    let(:procedure_draft) { create :procedure, published_at: nil, archived: false }
+    let(:procedure_published) { create :procedure, published_at: Time.now, archived: false }
+    let(:procedure_archived) { create :procedure, published_at: nil, archived: true }
 
     subject { delete :destroy, params: {id: procedure.id} }
 
@@ -94,8 +94,8 @@ describe Admin::ProceduresController, type: :controller do
   end
 
   describe 'GET #edit' do
-    let(:published) { false }
-    let(:procedure) { create(:procedure, administrateur: admin, published: published) }
+    let(:published_at) { nil }
+    let(:procedure) { create(:procedure, administrateur: admin, published_at: published_at) }
     let(:procedure_id) { procedure.id }
 
     subject { get :edit, params: {id: procedure_id} }
@@ -115,7 +115,7 @@ describe Admin::ProceduresController, type: :controller do
       end
 
       context 'when procedure is published' do
-        let(:published) { true }
+        let(:published_at) { Time.now }
         it { is_expected.to have_http_status(:success) }
       end
 
@@ -297,7 +297,7 @@ describe Admin::ProceduresController, type: :controller do
         let(:procedure_path) { 'new_path' }
 
         it 'publish the given procedure' do
-          expect(procedure.published).to be_truthy
+          expect(procedure.published?).to be_truthy
           expect(procedure.path).to eq(procedure_path)
           expect(response.status).to eq 200
           expect(flash[:notice]).to have_content 'Procédure publiée'
@@ -308,14 +308,14 @@ describe Admin::ProceduresController, type: :controller do
         let(:procedure_path) { procedure2.path }
 
         it 'publish the given procedure' do
-          expect(procedure.published).to be_truthy
+          expect(procedure.published?).to be_truthy
           expect(procedure.path).to eq(procedure_path)
           expect(response.status).to eq 200
           expect(flash[:notice]).to have_content 'Procédure publiée'
         end
 
         it 'archive previous procedure' do
-          expect(procedure2.published).to be_truthy
+          expect(procedure2.published?).to be_truthy
           expect(procedure2.archived).to be_truthy
           expect(procedure2.path).to be_nil
         end
@@ -325,13 +325,13 @@ describe Admin::ProceduresController, type: :controller do
         let(:procedure_path) { procedure3.path }
 
         it 'does not publish the given procedure' do
-          expect(procedure.published).to be_falsey
+          expect(procedure.published?).to be_falsey
           expect(procedure.path).to be_nil
           expect(response.status).to eq 200
         end
 
         it 'previous procedure remains published' do
-          expect(procedure2.published).to be_truthy
+          expect(procedure2.published?).to be_truthy
           expect(procedure2.archived).to be_falsey
           expect(procedure2.path).to match(/fake_path/)
         end
@@ -341,7 +341,7 @@ describe Admin::ProceduresController, type: :controller do
         let(:procedure_path) { 'Invalid Procedure Path' }
 
         it 'does not publish the given procedure' do
-          expect(procedure.published).to be_falsey
+          expect(procedure.published?).to be_falsey
           expect(procedure.path).to be_nil
           expect(response).to redirect_to :admin_procedures
           expect(flash[:alert]).to have_content 'Lien de la procédure invalide'

--- a/spec/controllers/admin/types_de_champ_controller_spec.rb
+++ b/spec/controllers/admin/types_de_champ_controller_spec.rb
@@ -9,8 +9,8 @@ describe Admin::TypesDeChampController, type: :controller do
   end
 
   describe 'GET #show' do
-    let(:published) { false }
-    let(:procedure) { create(:procedure, administrateur: admin, published: published) }
+    let(:published_at) { nil }
+    let(:procedure) { create(:procedure, administrateur: admin, published_at: published_at) }
     let(:procedure_id) { procedure.id }
 
     subject { get :show, params: {procedure_id: procedure_id} }
@@ -21,7 +21,7 @@ describe Admin::TypesDeChampController, type: :controller do
     end
 
     context 'when procedure is published' do
-      let(:published) { true }
+      let(:published_at) { Time.now }
       it { is_expected.to redirect_to admin_procedure_path id: procedure_id }
     end
 

--- a/spec/controllers/admin/types_de_champ_private_controller_spec.rb
+++ b/spec/controllers/admin/types_de_champ_private_controller_spec.rb
@@ -9,8 +9,8 @@ describe Admin::TypesDeChampPrivateController, type: :controller do
   end
 
   describe 'GET #show' do
-    let(:published) { false }
-    let(:procedure) { create(:procedure, administrateur: admin, published: published) }
+    let(:published_at) { nil }
+    let(:procedure) { create(:procedure, administrateur: admin, published_at: published_at) }
     let(:procedure_id) { procedure.id }
 
     subject { get :show, params: {procedure_id: procedure_id} }
@@ -21,7 +21,7 @@ describe Admin::TypesDeChampPrivateController, type: :controller do
     end
 
     context 'when procedure is published' do
-      let(:published) { true }
+      let(:published_at) { Time.now }
       it { is_expected.to redirect_to admin_procedure_path id: procedure_id }
     end
 

--- a/spec/controllers/api/v1/procedures_controller_spec.rb
+++ b/spec/controllers/api/v1/procedures_controller_spec.rb
@@ -34,7 +34,7 @@ describe API::V1::ProceduresController, type: :controller do
         it { expect(subject[:organisation]).to eq(procedure.organisation) }
         it { expect(subject[:direction]).to eq(procedure.direction) }
         it { expect(subject[:link]).to eq(procedure.lien_demarche) }
-        it { expect(subject[:archived]).to eq(procedure.archived) }
+        it { expect(subject[:archived_at]).to eq(procedure.archived_at) }
         it { expect(subject[:total_dossier]).to eq(procedure.total_dossier) }
         it { is_expected.to have_key(:types_de_champ) }
         it { expect(subject[:types_de_champ]).to be_an(Array) }

--- a/spec/controllers/stats_controller_spec.rb
+++ b/spec/controllers/stats_controller_spec.rb
@@ -118,18 +118,18 @@ describe StatsController, type: :controller do
 
     before do
       3.times do
-        create(:procedure, published: true, administrateur: administrateur_1)
+        create(:procedure, published_at: Time.now, administrateur: administrateur_1)
       end
 
       2.times do
-        create(:procedure, published: true, administrateur: administrateur_2)
+        create(:procedure, published_at: Time.now, administrateur: administrateur_2)
       end
 
       8.times do
-        create(:procedure, published: true, administrateur: administrateur_3)
+        create(:procedure, published_at: Time.now, administrateur: administrateur_3)
       end
 
-      create(:procedure, published: true, administrateur: administrateur_4)
+      create(:procedure, published_at: Time.now, administrateur: administrateur_4)
     end
 
     let(:association){ Procedure.all }

--- a/spec/controllers/users/description_controller_shared_example.rb
+++ b/spec/controllers/users/description_controller_shared_example.rb
@@ -26,7 +26,7 @@ shared_examples 'description_controller_spec' do
 
       context 'procedure is archived' do
         render_views
-        let(:archived) { true }
+        let(:archived_at) { Time.now }
 
         it { expect(response).to have_http_status(:success) }
         it { expect(response.body).to_not have_content(I18n.t('errors.messages.procedure_archived')) }
@@ -298,7 +298,7 @@ shared_examples 'description_controller_spec' do
     end
 
     context 'La procédure est archivée' do
-      let(:archived) { true }
+      let(:archived_at) { Time.now }
 
       before do
         post :update, params: { dossier_id: dossier.id }

--- a/spec/controllers/users/description_controller_spec.rb
+++ b/spec/controllers/users/description_controller_spec.rb
@@ -5,10 +5,10 @@ require 'controllers/users/description_controller_shared_example'
 describe Users::DescriptionController, type: :controller, vcr: {cassette_name: 'controllers_users_description_controller'} do
   let(:owner_user) { create(:user) }
   let(:invite_by_user) { create :user, email: 'invite@plop.com' }
-  let(:archived) { false }
+  let(:archived_at) { nil }
   let(:state) { 'initiated' }
 
-  let(:procedure) { create(:procedure, :with_two_type_de_piece_justificative, :with_type_de_champ, :with_datetime, cerfa_flag: true, archived: archived) }
+  let(:procedure) { create(:procedure, :with_two_type_de_piece_justificative, :with_type_de_champ, :with_datetime, cerfa_flag: true, archived_at: archived_at) }
   let(:dossier) { create(:dossier, procedure: procedure, user: owner_user, state: state) }
 
   let(:dossier_id) { dossier.id }

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -140,7 +140,7 @@ describe Users::DossiersController, type: :controller do
       end
 
       context 'when procedure is not published' do
-        let(:procedure) { create(:procedure, published: false) }
+        let(:procedure) { create(:procedure, published_at: nil) }
 
         before do
           sign_in user

--- a/spec/controllers/users/dossiers_controller_spec.rb
+++ b/spec/controllers/users/dossiers_controller_spec.rb
@@ -118,7 +118,7 @@ describe Users::DossiersController, type: :controller do
           end
 
           context 'when procedure is archived' do
-            let(:procedure) { create(:procedure, archived: 'true') }
+            let(:procedure) { create(:procedure, archived_at: Time.now) }
 
             it { is_expected.to redirect_to users_dossiers_path }
           end
@@ -158,10 +158,10 @@ describe Users::DossiersController, type: :controller do
     it { expect(subject).to redirect_to new_users_dossier_path(procedure_id: procedure.id) }
 
     context 'when procedure is archived' do
-      let(:procedure) { create(:procedure, :published, archived: true) }
+      let(:procedure) { create(:procedure, :published, archived_at: Time.now) }
 
       before do
-        procedure.update_column :archived, true
+        procedure.update_column :archived_at, Time.now
       end
 
       it { expect(subject.status).to eq 200 }

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -220,7 +220,7 @@ describe Users::SessionsController, type: :controller do
       end
 
       context 'when procedure is not published' do
-        let(:procedure) { create :procedure, published: false }
+        let(:procedure) { create :procedure, published_at: nil }
         before do
           session["user_return_to"] = "?procedure_id=#{procedure.id}"
         end
@@ -230,7 +230,7 @@ describe Users::SessionsController, type: :controller do
       end
 
       context 'when procedure_id exist' do
-        let(:procedure) { create :procedure, published: true }
+        let(:procedure) { create :procedure, published_at: Time.now }
 
         before do
           session["user_return_to"] = "?procedure_id=#{procedure.id}"

--- a/spec/factories/procedure.rb
+++ b/spec/factories/procedure.rb
@@ -6,7 +6,7 @@ FactoryGirl.define do
     description "Demande de subvention à l'intention des associations"
     organisation "Orga SGMAP"
     direction "direction SGMAP"
-    published false
+    published_at nil
     cerfa_flag false
     administrateur { create(:administrateur) }
 

--- a/spec/features/admin/procedure_locked_spec.rb
+++ b/spec/features/admin/procedure_locked_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 feature 'procedure locked' do
   let(:administrateur) { create(:administrateur) }
-  let(:published) { false }
-  let(:procedure) { create(:procedure, administrateur: administrateur, published: published) }
+  let (:published_at) { nil }
+  let(:procedure) { create(:procedure, administrateur: administrateur, published_at: published_at) }
 
   before do
     login_as administrateur, scope: :administrateur

--- a/spec/models/gestionnaire_spec.rb
+++ b/spec/models/gestionnaire_spec.rb
@@ -370,14 +370,14 @@ describe Gestionnaire, type: :model do
     end
 
     context 'when no procedure published was active last week' do
-      let!(:procedure) { create(:procedure, gestionnaires: [gestionnaire2], libelle: 'procedure', published: true) }
+      let!(:procedure) { create(:procedure, gestionnaires: [gestionnaire2], libelle: 'procedure', published_at: Time.now) }
       context 'when the gestionnaire has no notifications' do
         it { is_expected.to eq(nil) }
       end
     end
 
     context 'when a procedure published was active' do
-      let!(:procedure) { create(:procedure, gestionnaires: [gestionnaire2], libelle: 'procedure', published: true) }
+      let!(:procedure) { create(:procedure, gestionnaires: [gestionnaire2], libelle: 'procedure', published_at: Time.now) }
       let(:procedure_overview) { double('procedure_overview', 'had_some_activities?'.to_sym => true) }
 
       before :each do
@@ -388,7 +388,7 @@ describe Gestionnaire, type: :model do
     end
 
     context 'when a procedure not published was active with no notifications' do
-      let!(:procedure) { create(:procedure, gestionnaires: [gestionnaire2], libelle: 'procedure', published: false) }
+      let!(:procedure) { create(:procedure, gestionnaires: [gestionnaire2], libelle: 'procedure', published_at: nil) }
       let(:procedure_overview) { double('procedure_overview', 'had_some_activities?'.to_sym => true) }
 
       before :each do

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -113,38 +113,38 @@ describe Procedure do
   end
 
   describe 'active' do
-    let(:procedure) { create(:procedure, published_at: published_at, archived: archived) }
+    let(:procedure) { create(:procedure, published_at: published_at, archived_at: archived_at) }
     subject { Procedure.active(procedure.id) }
 
     context 'when procedure is in draft status and not archived' do
       let(:published_at) { nil }
-      let(:archived) { false }
+      let(:archived_at) { nil }
       it { expect { subject }.to raise_error(ActiveRecord::RecordNotFound) }
     end
 
     context 'when procedure is published and not archived' do
       let(:published_at) { Time.now }
-      let(:archived) { false }
+      let(:archived_at) { nil }
       it { is_expected.to be_truthy }
     end
 
     context 'when procedure is published and archived' do
       let(:published_at) { Time.now }
-      let(:archived) { true }
+      let(:archived_at) { Time.now }
       it { expect { subject }.to raise_error(ActiveRecord::RecordNotFound) }
     end
 
     context 'when procedure is in draft status and archived' do
       let(:published_at) { nil }
-      let(:archived) { true }
+      let(:archived_at) { Time.now }
       it { expect { subject }.to raise_error(ActiveRecord::RecordNotFound) }
     end
   end
 
   describe 'clone' do
-    let(:archived) { false }
+    let(:archived_at) { nil }
     let(:published_at) { nil }
-    let(:procedure) { create(:procedure, archived: archived, published_at: published_at, received_mail: received_mail) }
+    let(:procedure) { create(:procedure, archived_at: archived_at, published_at: published_at, received_mail: received_mail) }
     let!(:type_de_champ_0) { create(:type_de_champ_public, procedure: procedure, order_place: 0) }
     let!(:type_de_champ_1) { create(:type_de_champ_public, procedure: procedure, order_place: 1) }
     let!(:type_de_champ_2) { create(:type_de_champ_public, :type_drop_down_list, procedure: procedure, order_place: 2) }
@@ -213,10 +213,10 @@ describe Procedure do
     end
 
     describe 'procedure status is reset' do
-      let(:archived) { true }
+      let(:archived_at) { Time.now }
       let(:published_at) { Time.now }
       it 'Not published nor archived' do
-        expect(subject.archived).to be_falsey
+        expect(subject.archived_at).to be_nil
         expect(subject.published_at).to be_nil
         expect(subject.path).to be_nil
       end
@@ -232,7 +232,7 @@ describe Procedure do
       procedure.publish!("example-path")
     end
 
-    it { expect(procedure.archived).to eq(false) }
+    it { expect(procedure.archived_at).to eq(nil) }
     it { expect(procedure.published_at).to eq(now) }
     it { expect(ProcedurePath.find_by_path("example-path")).to be }
     it { expect(ProcedurePath.find_by_path("example-path").procedure).to eq(procedure) }
@@ -254,7 +254,7 @@ describe Procedure do
     end
 
     it { expect(procedure.published?).to be_truthy }
-    it { expect(procedure.archived).to be_truthy }
+    it { expect(procedure.archived?).to be_truthy }
     it { expect(procedure.archived_at).to eq(now) }
 
     after do

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -97,45 +97,45 @@ describe Procedure do
   end
 
   describe 'locked?' do
-    let(:procedure) { create(:procedure, published: published) }
+    let(:procedure) { create(:procedure, published_at: published_at) }
 
     subject { procedure.locked? }
 
     context 'when procedure is in draft status' do
-      let(:published) { false }
+      let(:published_at) { nil }
       it { is_expected.to be_falsey }
     end
 
     context 'when procedure is in draft status' do
-      let(:published) { true }
+      let(:published_at) { Time.now }
       it { is_expected.to be_truthy }
     end
   end
 
   describe 'active' do
-    let(:procedure) { create(:procedure, published: published, archived: archived) }
+    let(:procedure) { create(:procedure, published_at: published_at, archived: archived) }
     subject { Procedure.active(procedure.id) }
 
     context 'when procedure is in draft status and not archived' do
-      let(:published) { false }
+      let(:published_at) { nil }
       let(:archived) { false }
       it { expect { subject }.to raise_error(ActiveRecord::RecordNotFound) }
     end
 
     context 'when procedure is published and not archived' do
-      let(:published) { true }
+      let(:published_at) { Time.now }
       let(:archived) { false }
       it { is_expected.to be_truthy }
     end
 
     context 'when procedure is published and archived' do
-      let(:published) { true }
+      let(:published_at) { Time.now }
       let(:archived) { true }
       it { expect { subject }.to raise_error(ActiveRecord::RecordNotFound) }
     end
 
     context 'when procedure is in draft status and archived' do
-      let(:published) { false }
+      let(:published_at) { nil }
       let(:archived) { true }
       it { expect { subject }.to raise_error(ActiveRecord::RecordNotFound) }
     end
@@ -143,8 +143,8 @@ describe Procedure do
 
   describe 'clone' do
     let(:archived) { false }
-    let(:published) { false }
-    let(:procedure) { create(:procedure, archived: archived, published: published, received_mail: received_mail) }
+    let(:published_at) { nil }
+    let(:procedure) { create(:procedure, archived: archived, published_at: published_at, received_mail: received_mail) }
     let!(:type_de_champ_0) { create(:type_de_champ_public, procedure: procedure, order_place: 0) }
     let!(:type_de_champ_1) { create(:type_de_champ_public, procedure: procedure, order_place: 1) }
     let!(:type_de_champ_2) { create(:type_de_champ_public, :type_drop_down_list, procedure: procedure, order_place: 2) }
@@ -214,10 +214,10 @@ describe Procedure do
 
     describe 'procedure status is reset' do
       let(:archived) { true }
-      let(:published) { true }
+      let(:published_at) { Time.now }
       it 'Not published nor archived' do
         expect(subject.archived).to be_falsey
-        expect(subject.published).to be_falsey
+        expect(subject.published_at).to be_nil
         expect(subject.path).to be_nil
       end
     end
@@ -232,7 +232,6 @@ describe Procedure do
       procedure.publish!("example-path")
     end
 
-    it { expect(procedure.published).to eq(true) }
     it { expect(procedure.archived).to eq(false) }
     it { expect(procedure.published_at).to eq(now) }
     it { expect(ProcedurePath.find_by_path("example-path")).to be }
@@ -254,7 +253,7 @@ describe Procedure do
       procedure.reload
     end
 
-    it { expect(procedure.published).to be_truthy }
+    it { expect(procedure.published?).to be_truthy }
     it { expect(procedure.archived).to be_truthy }
     it { expect(procedure.archived_at).to eq(now) }
 

--- a/spec/views/admin/procedures/show.html.haml_spec.rb
+++ b/spec/views/admin/procedures/show.html.haml_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'admin/procedures/show.html.haml', type: :view do
-  let(:archived) { false }
-  let(:procedure) { create(:procedure, archived: archived) }
+  let(:archived_at) { nil }
+  let(:procedure) { create(:procedure, archived_at: archived_at) }
 
   before do
     assign(:facade, AdminProceduresShowFacades.new(procedure.decorate))

--- a/spec/workers/auto_archive_procedure_worker_spec.rb
+++ b/spec/workers/auto_archive_procedure_worker_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe AutoArchiveProcedureWorker, type: :worker do
-  let!(:procedure) { create(:procedure, archived: false, auto_archive_on: nil )}
-  let!(:procedure_hier) { create(:procedure, archived: false, auto_archive_on: 1.day.ago )}
-  let!(:procedure_aujourdhui) { create(:procedure, archived: false, auto_archive_on: Date.today )}
-  let!(:procedure_demain) { create(:procedure, archived: false, auto_archive_on: 1.day.from_now )}
+  let!(:procedure) { create(:procedure, archived_at: nil, auto_archive_on: nil )}
+  let!(:procedure_hier) { create(:procedure, archived_at: nil, auto_archive_on: 1.day.ago )}
+  let!(:procedure_aujourdhui) { create(:procedure, archived_at: nil, auto_archive_on: Date.today )}
+  let!(:procedure_demain) { create(:procedure, archived_at: nil, auto_archive_on: 1.day.from_now )}
 
   subject { AutoArchiveProcedureWorker.new.perform }
 
@@ -14,7 +14,7 @@ RSpec.describe AutoArchiveProcedureWorker, type: :worker do
       procedure.reload
     end
 
-    it { expect(procedure.archived).to eq false }
+    it { expect(procedure.archived?).to eq false }
   end
 
   context "when procedures have auto_archive_on set on yesterday or today" do
@@ -49,8 +49,8 @@ RSpec.describe AutoArchiveProcedureWorker, type: :worker do
     it { expect(dossier8.state).to eq 'without_continuation' }
     it { expect(dossier9.state).to eq 'received' }
 
-    it { expect(procedure_hier.archived).to eq true }
-    it { expect(procedure_aujourdhui.archived).to eq true }
+    it { expect(procedure_hier.archived?).to eq true }
+    it { expect(procedure_aujourdhui.archived?).to eq true }
   end
 
   context "when procedures have auto_archive_on set on future" do
@@ -58,6 +58,6 @@ RSpec.describe AutoArchiveProcedureWorker, type: :worker do
       subject
     end
 
-    it { expect(procedure_demain.archived).to eq false }
+    it { expect(procedure_demain.archived?).to eq false }
   end
 end


### PR DESCRIPTION
To run before merging / deploying

```ruby
# Write published_at
Procedure.unscoped.where(published_at: nil).where.not(procedure_path: nil).each do |p|
  published_at = p.procedure_path.created_at
  p.update_columns(published_at: published_at)
end

# Write archived_at
Procedure.unscoped.where(archived_at: nil).where(archived: true).each do |p|
  archived_at = p.updated_at
  p.update_columns(archived_at: archived_at)
end
```