### PR TITLE
When procedure libelle is too long, don't shrink logo or button

### DIFF
--- a/app/assets/stylesheets/new_design/procedure_list.scss
+++ b/app/assets/stylesheets/new_design/procedure_list.scss
@@ -29,6 +29,7 @@
     height: 93px;
     width: 93px;
     margin-right: 3 * $default-spacer;
+    flex-shrink: 0;
   }
 
   .procedure-title {

--- a/app/assets/stylesheets/new_design/procedures_show.scss
+++ b/app/assets/stylesheets/new_design/procedures_show.scss
@@ -5,6 +5,7 @@
 #procedure-show {
   .procedure-logo {
     margin-right: $default-padding;
+    flex-shrink: 0;
   }
 
   h1 {
@@ -19,6 +20,7 @@
 
   .procedure-actions {
     margin-left: auto;
+    flex-shrink: 0;
 
     .dropdown-items li {
       min-width: 150px;


### PR DESCRIPTION
Avant :
<img width="1072" alt="capture d ecran 2017-09-21 a 15 17 09" src="https://user-images.githubusercontent.com/847942/30697773-60a43cec-9ee0-11e7-879d-2a28c99c4226.png">

Après :
<img width="1080" alt="capture d ecran 2017-09-21 a 15 20 04" src="https://user-images.githubusercontent.com/847942/30697797-706c9016-9ee0-11e7-9f74-f575352ebca2.png">
