### PR TITLE
Fix special chars on homepage

### DIFF
--- a/app/views/root/landing.html.haml
+++ b/app/views/root/landing.html.haml
@@ -34,7 +34,7 @@
           %p.feature-text
             %em.feature-text-em Gérer
             %br
-            les demandes des usagers 
+            les demandes des usagers
             %br
             sur la plateforme
         %li.feature
@@ -42,7 +42,7 @@
           %p.feature-text
             %em.feature-text-em Collaborer
             %br
-            pour instruire les demandes 
+            pour instruire les demandes
             %br
             à plusieurs
 


### PR DESCRIPTION
Deux  LSEP apparaissent sur la home (Chrome, Windows, capture d'écran). Je les ai supprimé du fichier où ils apparaissent.

![lsep](https://user-images.githubusercontent.com/25476945/31219959-383ec4cc-a9bf-11e7-8828-7e1f56d0506f.png)
