### PR TITLE
Avoid loading the association for the without_followers scope

### DIFF
--- a/app/models/dossier.rb
+++ b/app/models/dossier.rb
@@ -60,7 +60,7 @@ class Dossier < ActiveRecord::Base
   scope :termine,                     -> { not_archived.state_termine }
   scope :downloadable,                -> { state_not_brouillon.includes(:entreprise, :etablissement, :champs, :champs_private) }
   scope :en_cours,                    -> { not_archived.state_en_construction_ou_instruction }
-  scope :without_followers,           -> { includes(:follows).where(follows: { id: nil }) }
+  scope :without_followers,           -> { left_outer_joins(:follows).where(follows: { id: nil }) }
   scope :with_unread_notifications,   -> { where(notifications: { already_read: false }) }
 
   accepts_nested_attributes_for :individual

--- a/spec/models/dossier_spec.rb
+++ b/spec/models/dossier_spec.rb
@@ -3,6 +3,13 @@ require 'spec_helper'
 describe Dossier do
   let(:user) { create(:user) }
 
+  describe "without_followers scope" do
+    let!(:dossier) { create(:dossier, :followed, :with_entreprise, user: user) }
+    let!(:dossier2) { create(:dossier, :with_entreprise, user: user) }
+
+    it { expect(Dossier.without_followers.to_a).to eq([dossier2]) }
+  end
+
   describe 'methods' do
     let(:dossier) { create(:dossier, :with_entreprise, user: user) }
 


### PR DESCRIPTION
As seen in https://stackoverflow.com/questions/5319400/want-to-find-records-with-no-associated-records-in-rails-3