### PR TITLE
In vertical tables, invert the bold styling

### DIFF
--- a/app/assets/stylesheets/new_design/table.scss
+++ b/app/assets/stylesheets/new_design/table.scss
@@ -36,17 +36,11 @@
 
     th {
       @include vertical-padding($default-spacer);
-      font-weight: normal;
 
       &.header-section {
         color: $blue;
-        font-weight: bold;
         font-size: 20px;
       }
-    }
-
-    td {
-      font-weight: bold;
     }
   }
 }


### PR DESCRIPTION
the label is now in bold, and the value in a
normal weight:
- it is more usual
- it allows the value to contain bold styling