### PR TITLE
[Fix #807] dossiers-table improvements + allow 5 columns

### DIFF
--- a/app/assets/javascripts/new_design/champs/multiple_drop_down_list.js
+++ b/app/assets/javascripts/new_design/champs/multiple_drop_down_list.js
@@ -3,7 +3,7 @@ document.addEventListener('turbolinks:load', function() {
 
   $('select.select2-limited').select2({
     'placeholder': 'Sélectionnez des colonnes',
-    'maximumSelectionLength': '2',
+    'maximumSelectionLength': '5',
     'width': '300px'
   });
 });

--- a/app/assets/stylesheets/new_design/dossiers_table.scss
+++ b/app/assets/stylesheets/new_design/dossiers_table.scss
@@ -39,7 +39,7 @@
     width: 130px;
   }
 
-  .status-col span {
+  .status-col .label {
     width: 110px;
     text-align: center;
   }

--- a/app/assets/stylesheets/new_design/dossiers_table.scss
+++ b/app/assets/stylesheets/new_design/dossiers_table.scss
@@ -6,7 +6,7 @@
 
   th {
     vertical-align: middle;
-    padding: (2 * $default-spacer) 2px;
+    padding: (2 * $default-spacer) $default-spacer;
   }
 
   td {
@@ -28,7 +28,7 @@
     // In order to have identical height in the table header and the table rows,
     // we compensate for the height difference between the biggest element of the header
     // (the Personnaliser button, 38px) and the biggest cell-link element of the rows (the label, 28px)
-    padding: calc((2 * #{$default-spacer}) + ((38px - 28px) / 2)) 2px;
+    padding: calc((2 * #{$default-spacer}) + ((38px - 28px) / 2)) $default-spacer;
     display: block;
   }
 
@@ -58,5 +58,7 @@
   .follow-col {
     width: 190px;
     text-align: right;
+    padding-left: $default-spacer;
+    padding-right: $default-spacer;
   }
 }

--- a/app/assets/stylesheets/new_design/dossiers_table.scss
+++ b/app/assets/stylesheets/new_design/dossiers_table.scss
@@ -49,6 +49,6 @@
 
   .follow-col {
     width: 190px;
-    text-align: center;
+    text-align: right;
   }
 }

--- a/app/assets/stylesheets/new_design/dossiers_table.scss
+++ b/app/assets/stylesheets/new_design/dossiers_table.scss
@@ -4,6 +4,10 @@
 .table.dossiers-table {
   font-size: 14px;
 
+  th {
+    vertical-align: middle;
+  }
+
   td {
     padding: 0;
   }

--- a/app/assets/stylesheets/new_design/dossiers_table.scss
+++ b/app/assets/stylesheets/new_design/dossiers_table.scss
@@ -34,18 +34,21 @@
     }
   }
 
-  .number-col,
-  .status-col {
-    width: 130px;
+  .number-col {
+    width: 110px;
   }
 
-  .status-col .label {
+  .status-col {
     width: 110px;
-    text-align: center;
+
+    .label {
+      width: 110px;
+      text-align: center;
+    }
   }
 
   .follow-col {
-    width: 200px;
+    width: 190px;
     text-align: center;
   }
 }

--- a/app/assets/stylesheets/new_design/dossiers_table.scss
+++ b/app/assets/stylesheets/new_design/dossiers_table.scss
@@ -2,6 +2,8 @@
 @import "constants";
 
 .table.dossiers-table {
+  font-size: 14px;
+
   td {
     padding: 0;
   }

--- a/app/assets/stylesheets/new_design/dossiers_table.scss
+++ b/app/assets/stylesheets/new_design/dossiers_table.scss
@@ -6,6 +6,7 @@
 
   th {
     vertical-align: middle;
+    padding: (2 * $default-spacer) 2px;
   }
 
   td {
@@ -24,7 +25,10 @@
 
   .cell-link {
     color: $black;
-    padding: (3 * $default-spacer) 2px;
+    // In order to have identical height in the table header and the table rows,
+    // we compensate for the height difference between the biggest element of the header
+    // (the Personnaliser button, 38px) and the biggest cell-link element of the rows (the label, 28px)
+    padding: calc((2 * #{$default-spacer}) + ((38px - 28px) / 2)) 2px;
     display: block;
   }
 

--- a/app/assets/stylesheets/new_design/labels.scss
+++ b/app/assets/stylesheets/new_design/labels.scss
@@ -9,6 +9,7 @@
   color: #FFFFFF;
   border-radius: 4px;
   font-size: 12px;
+  line-height: 18px;
 
   &.instruction {
     background-color: #FFFFFF;

--- a/app/assets/stylesheets/new_design/procedures_show.scss
+++ b/app/assets/stylesheets/new_design/procedures_show.scss
@@ -15,7 +15,8 @@
   }
 
   .dossiers-table {
-    margin: (3 * $default-spacer) auto;
+    margin-top: $default-spacer;
+    margin-bottom: 3 * $default-spacer;
   }
 
   .procedure-actions {


### PR DESCRIPTION
Avant :

<img width="1392" alt="screen shot 2017-10-17 at 18 56 15" src="https://user-images.githubusercontent.com/1333173/31678095-4f5ea64c-b36d-11e7-8d66-092a1b3d472d.png">

Après :

<img width="1392" alt="screen shot 2017-10-17 at 18 56 06" src="https://user-images.githubusercontent.com/1333173/31678096-50b3268a-b36d-11e7-9a4c-b2e9d3835bd1.png">
