### PR TITLE
[fix #872] Procedure Logo: fix overflow logo for ie11

### DIFF
--- a/app/assets/stylesheets/new_design/procedure_list.scss
+++ b/app/assets/stylesheets/new_design/procedure_list.scss
@@ -30,6 +30,10 @@
     width: 93px;
     margin-right: 3 * $default-spacer;
     flex-shrink: 0;
+    background-image: url("your/url/here");
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: 95% 50%;
   }
 
   .procedure-title {

--- a/app/views/new_gestionnaire/procedures/index.html.haml
+++ b/app/views/new_gestionnaire/procedures/index.html.haml
@@ -7,9 +7,7 @@
         = link_to(procedure_path(p)) do
           .flex
 
-            .procedure-logo
-              - if p.logo.present?
-                = image_tag p.logo, alt: "Logo de la procédure"
+            .procedure-logo{ style: p.logo.present? ? "background-image: url(#{p.logo.url})" : nil }
 
             .procedure-details
               %p.procedure-title


### PR DESCRIPTION
Bug in ie11 linked to flex and image ratio
The only way to fix it so far and preserving image ratio is to use background image property