### PR TITLE
Remove now useless encoding statements

### DIFF
--- a/app/uploaders/base_uploader.rb
+++ b/app/uploaders/base_uploader.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class BaseUploader < CarrierWave::Uploader::Base
   def cache_dir
     if Rails.env.production?

--- a/app/uploaders/cerfa_uploader.rb
+++ b/app/uploaders/cerfa_uploader.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class CerfaUploader < BaseUploader
   before :cache, :set_original_filename
 

--- a/app/uploaders/piece_justificative_uploader.rb
+++ b/app/uploaders/piece_justificative_uploader.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class PieceJustificativeUploader < BaseUploader
   before :cache, :set_original_filename
 

--- a/app/uploaders/procedure_logo_uploader.rb
+++ b/app/uploaders/procedure_logo_uploader.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class ProcedureLogoUploader < BaseUploader
   def root
     File.join(Rails.root, "public")


### PR DESCRIPTION
As utf-8 is the default encoding since Ruby 2,
this is no longer needed