### PR TITLE
[Fix #432] Stop raising a useless exception in get_position

### DIFF
--- a/app/controllers/users/carte_controller.rb
+++ b/app/controllers/users/carte_controller.rb
@@ -31,7 +31,12 @@ class Users::CarteController < UsersController
   end
 
   def get_position
-    etablissement = current_user_dossier.etablissement
+    begin
+      etablissement = current_user_dossier.etablissement
+    rescue ActiveRecord::RecordNotFound
+      etablissement = nil
+    end
+
     point = Carto::Geocodeur.convert_adresse_to_point(etablissement.geo_adresse) unless etablissement.nil?
 
     lon = '2.428462'


### PR DESCRIPTION
When an accompagnateur, in the old UI, wants to
see a map, this call crashes because he’s not
the owner or invitee on the dossier he’s looking
at, therefore current_user_dossier raises an
exception