### PR TITLE
[Fix #957] Use select2 for all menu deroulant

### DIFF
--- a/app/views/users/description/champs/_drop_down_list.html.haml
+++ b/app/views/users/description/champs/_drop_down_list.html.haml
@@ -4,4 +4,4 @@
       selected: champ.drop_down_list.selected_options(champ),
       disabled: champ.drop_down_list.disabled_options),
       multiple: champ.drop_down_list.multiple,
-      class: champ.drop_down_list.multiple ? 'select2' : nil)
+      class: 'select2')


### PR DESCRIPTION
Displays options that are too long on mutilple lines