### PR TITLE
[fix #1053] An Administrateur can choose the final dossier states

### DIFF
--- a/app/jobs/auto_receive_dossiers_for_procedure_job.rb
+++ b/app/jobs/auto_receive_dossiers_for_procedure_job.rb
@@ -1,10 +1,10 @@
 class AutoReceiveDossiersForProcedureJob < ApplicationJob
   queue_as :cron
 
-  def perform(procedure_id)
+  def perform(procedure_id, state)
     procedure = Procedure.find_by(id: procedure_id)
     if procedure
-      procedure.dossiers.state_nouveaux.update_all(state: "received", received_at: Time.now)
+      procedure.dossiers.state_nouveaux.update_all(state: state, received_at: Time.now)
     end
   end
 end

--- a/spec/jobs/auto_receive_dossiers_for_procedure_job_spec.rb
+++ b/spec/jobs/auto_receive_dossiers_for_procedure_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AutoReceiveDossiersForProcedureJob, type: :job do
     before { Timecop.freeze(date) }
     after { Timecop.return }
 
-    subject { AutoReceiveDossiersForProcedureJob.new.perform(procedure_id) }
+    subject { AutoReceiveDossiersForProcedureJob.new.perform(procedure_id, 'received') }
 
     context "with some dossiers" do
       let(:nouveau_dossier1) { create(:dossier, :initiated) }


### PR DESCRIPTION
! before going to production :
- stopping the current AutoReceiveJob
- relaunch the jobs with previous id and state = 'received'