### PR TITLE
If answer is missing on avis, notify on avis tab

### DIFF
--- a/app/views/new_gestionnaire/avis/_header.html.haml
+++ b/app/views/new_gestionnaire/avis/_header.html.haml
@@ -9,5 +9,7 @@
         = link_to 'Demande', avis_path(avis)
       %li{ class: current_page?(instruction_avis_path(avis)) ? 'active' : nil }
         = link_to 'Avis', instruction_avis_path(avis)
+        - if avis.answer == nil
+          %span.notifications{ 'aria-label': 'notifications' }
       %li{ class: current_page?(messagerie_avis_path(avis)) ? 'active' : nil }
         = link_to 'Messagerie', messagerie_avis_path(avis)


### PR DESCRIPTION
On avait mis la pastille orange sur la page de liste des avis, mais pas sur la page de détails d'un avis.
<img width="413" alt="capture d ecran 2017-12-14 a 18 22 36" src="https://user-images.githubusercontent.com/847942/34006025-30c548a4-e0fd-11e7-9a81-6e72f396c4e9.png">
