### PR TITLE
[Fix #1102] Améliorer le texte qui explique ce qu'est un avis confidentiel

### DIFF
--- a/app/assets/javascripts/new_design/avis.js
+++ b/app/assets/javascripts/new_design/avis.js
@@ -1,0 +1,3 @@
+TPS.toggleCondidentielExplanation = function(event) {
+  $(".confidentiel-explanation").toggle();
+}

--- a/app/assets/stylesheets/new_design/avis.scss
+++ b/app/assets/stylesheets/new_design/avis.scss
@@ -59,6 +59,18 @@
       display: inline-block;
     }
   }
+
+  .lock {
+    margin-right: $default-spacer;
+  }
+
+  .confidentiel-explanation {
+    display: none;
+    font-size: 14px;
+    color: $grey;
+    margin-top: -$default-padding;
+    margin-bottom: 2 * $default-padding;
+  }
 }
 
 .list-avis {

--- a/app/views/new_gestionnaire/avis/instruction.html.haml
+++ b/app/views/new_gestionnaire/avis/instruction.html.haml
@@ -14,9 +14,10 @@
     = form_for @avis, url: avis_path(@avis), html: { class: 'form' } do |f|
       = f.text_area :answer, rows: 3, placeholder: 'Votre avis', required: true
       .flex.justify-between.align-baseline
-        %p.confidentiel
+        %p.confidentiel.flex
           %span.icon.lock
-          Cet avis est confidentiel et n'est pas affiché aux autres experts consultés
+          %span
+            Cet avis est confidentiel et n'est pas affiché aux autres experts consultés
         .send-wrapper
           = f.submit 'Envoyer votre avis', class: 'button send'
 

--- a/app/views/new_gestionnaire/shared/avis/_form.html.haml
+++ b/app/views/new_gestionnaire/shared/avis/_form.html.haml
@@ -7,14 +7,17 @@
     = f.text_area :introduction, rows: 3, value: 'Bonjour, merci de me donner votre avis sur ce dossier.', required: true
     .flex.justify-between.align-baseline
       - if must_be_confidentiel
-        %p.confidentiel
+        %p.confidentiel.flex
           %span.icon.lock
-          Cet avis est confidentiel et n'est pas affiché aux autres experts consultés
+          %span
+            Cet avis est confidentiel et n'est pas affiché aux autres experts consultés mais est visible par tous les accompagnateurs
         .send-wrapper
           = f.submit 'Demander un avis', class: 'button send'
       - else
         .confidentiel-wrapper
           = f.label :confidentiel, 'Cet avis est'
-          = f.select :confidentiel, [['partagé avec les autres experts', false], ['confidentiel', true]]
+          = f.select :confidentiel, [['partagé avec les autres experts', false], ['confidentiel', true]], {}, onchange: "javascript:TPS.toggleCondidentielExplanation(event);"
+          .confidentiel-explanation
+            Il ne sera pas affiché aux autres experts consultés mais sera visible par les accompagnateurs
         .send-wrapper
           = f.submit 'Demander un avis', class: 'button send'


### PR DESCRIPTION
J'ai choisi de n'afficher l'explication complète que dans la partie où on demande un avis à quelqu'un, et de ne pas nous étendre :
- dans la partie où un expert rend son avis (car ça ne me semble pas important)
- dans la partie où on affiche les avis (car je pense qu'on n'a pas besoin de le préciser à cet endroit)