### PR TITLE
Fix flaky test

### DIFF
--- a/spec/controllers/stats_controller_spec.rb
+++ b/spec/controllers/stats_controller_spec.rb
@@ -240,6 +240,8 @@ describe StatsController, type: :controller do
 
   describe "#avis_average_answer_time" do
     before do
+      Timecop.freeze(Time.now)
+
       # 1 week ago
       create(:avis, answer: "voila ma réponse", created_at: 1.week.ago + 1.day, updated_at: 1.week.ago + 2.days) # 1 day
       create(:avis, created_at: 1.week.ago + 2.days)
@@ -254,6 +256,8 @@ describe StatsController, type: :controller do
       create(:avis, answer: "voila ma réponse2", created_at: 3.weeks.ago + 1.day, updated_at: 3.weeks.ago + 2.days) # 1 day
       create(:avis, answer: "voila ma réponse2", created_at: 3.weeks.ago + 1.day, updated_at: 1.week.ago + 5.days) # 18 day
     end
+
+    after { Timecop.return }
 
     subject { StatsController.new.send(:avis_average_answer_time) }
 


### PR DESCRIPTION
Trouvé dans https://circleci.com/gh/sgmap/tps/3517#tests/containers/3

```
  1) StatsController#avis_average_answer_time should include [1512120443, 9.5]
     Failure/Error: it { is_expected.to include [3.week.ago.to_i, 9.5] }
       expected [[1512120442, 9.5], [1512725242, 7.33], [1513330042, 1.0]] to include [1512120443, 9.5]
     # ./spec/controllers/stats_controller_spec.rb:263:in `block (3 levels) in <top (required)>'
```