### PR TITLE
Remove will paginate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,6 @@ gem 'haml-rails'
 gem 'bootstrap-sass', '~> 3.3.5'
 
 # Pagination
-gem 'will_paginate-bootstrap'
 gem 'kaminari'
 
 # Decorators

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -682,9 +682,6 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
-    will_paginate (3.1.5)
-    will_paginate-bootstrap (1.0.1)
-      will_paginate (>= 3.0.3)
     xml-simple (1.1.5)
     xpath (2.1.0)
       nokogiri (~> 1.3)
@@ -779,7 +776,6 @@ DEPENDENCIES
   vcr
   web-console
   webmock
-  will_paginate-bootstrap
   xray-rails
 
 BUNDLED WITH

--- a/app/controllers/api/v1/dossiers_controller.rb
+++ b/app/controllers/api/v1/dossiers_controller.rb
@@ -7,7 +7,7 @@ class API::V1::DossiersController < APIController
 
   def index
     procedure = current_administrateur.procedures.find(params[:procedure_id])
-    dossiers = procedure.dossiers.state_not_brouillon.paginate(page: params[:page])
+    dossiers = procedure.dossiers.state_not_brouillon.page(params[:page]).per(per_page)
 
     render json: { dossiers: dossiers.map{ |dossier| DossiersSerializer.new(dossier) }, pagination: pagination(dossiers) }, status: 200
   rescue ActiveRecord::RecordNotFound
@@ -35,8 +35,12 @@ class API::V1::DossiersController < APIController
   def pagination(dossiers)
     {
         page: dossiers.current_page,
-        resultats_par_page: dossiers.per_page,
+        resultats_par_page: dossiers.limit_value,
         nombre_de_page: dossiers.total_pages
     }
+  end
+
+  def per_page # inherited value from will_paginate
+    12
   end
 end

--- a/app/decorators/dossier_decorator.rb
+++ b/app/decorators/dossier_decorator.rb
@@ -1,7 +1,7 @@
 class DossierDecorator < Draper::Decorator
   include Rails.application.routes.url_helpers
 
-  delegate :current_page, :per_page, :offset, :total_entries, :total_pages
+  delegate :current_page, :limit_value, :total_pages
   delegate_all
 
   def first_creation

--- a/app/decorators/dossiers_decorator.rb
+++ b/app/decorators/dossiers_decorator.rb
@@ -1,3 +1,3 @@
 class DossiersDecorator < Draper::CollectionDecorator
-  delegate :current_page, :per_page, :offset, :total_entries, :total_pages
+  delegate :current_page, :limit_value, :total_pages
 end

--- a/app/decorators/procedures_decorator.rb
+++ b/app/decorators/procedures_decorator.rb
@@ -1,3 +1,3 @@
 class ProceduresDecorator < Draper::CollectionDecorator
-  delegate :current_page, :per_page, :offset, :total_entries, :total_pages
+  delegate :current_page, :limit_value, :total_pages
 end

--- a/config/initializers/will_paginate.rb
+++ b/config/initializers/will_paginate.rb
@@ -1,3 +1,0 @@
-require 'will_paginate'
-
-WillPaginate.per_page = 12

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -26,9 +26,6 @@ fr:
     no-commentaires: "Il n'y a aucun message dans le fil de discussion, n'hésitez pas à initier le premier."
     depositaire: "Dépositaire"
     pieces: "Pièces jointes"
-  will_paginate:
-    next_label: 'Suivant'
-    previous_label: 'Précédent'
   views:
     pagination:
       next: Suivant

--- a/spec/controllers/api/v1/dossiers_controller_spec.rb
+++ b/spec/controllers/api/v1/dossiers_controller_spec.rb
@@ -65,7 +65,7 @@ describe API::V1::DossiersController do
         let!(:dossier2) { create(:dossier, :with_entreprise, procedure: procedure, state: 'en_construction') }
 
         before do
-          allow(Dossier).to receive(:per_page).and_return(1)
+          allow(controller).to receive(:per_page).and_return(1)
         end
 
         describe 'pagination' do

--- a/spec/decorators/procedures_decorator_spec.rb
+++ b/spec/decorators/procedures_decorator_spec.rb
@@ -7,13 +7,12 @@ describe ProceduresDecorator do
     create(:procedure, :published,  created_at: Time.new(2015, 12, 24, 14, 10))
   end
 
-  let(:procedure) { Procedure.all.paginate(page: 1) }
+  let(:procedure) { Procedure.all.page(1) }
 
   subject { procedure.decorate }
 
   it { expect(subject.current_page).not_to be_nil }
-  it { expect(subject.per_page).not_to be_nil }
-  it { expect(subject.offset).not_to be_nil }
-  it { expect(subject.total_entries).not_to be_nil }
+  it { expect(subject.limit_value).not_to be_nil }
+  it { expect(subject.count).to eq(3) }
   it { expect(subject.total_pages).not_to be_nil }
 end


### PR DESCRIPTION
Lié à #1098

Problème rencontré : https://github.com/thoughtbot/administrate/issues/238
### TLDR; 
> Administrate uses kaminari, and will_paginate and kaminari don't play well together yet it seems.

Pas de nécessité de garder les deux gems donc j'ai enlevé will_paginate