### PR TITLE
Fix 1110 - 2. port mail tags to attestation

### DIFF
--- a/app/controllers/backoffice/dossiers_controller.rb
+++ b/app/controllers/backoffice/dossiers_controller.rb
@@ -123,8 +123,8 @@ class Backoffice::DossiersController < Backoffice::DossiersListController
       notice = "Dossier considéré comme sans suite."
       template = dossier.procedure.without_continuation_mail_template
     when "close"
-      dossier.attestation = dossier.build_attestation
       dossier.accepte!
+      dossier.attestation = dossier.build_attestation
       notice = "Dossier traité avec succès."
       template = dossier.procedure.closed_mail_template
     end

--- a/app/controllers/new_gestionnaire/dossiers_controller.rb
+++ b/app/controllers/new_gestionnaire/dossiers_controller.rb
@@ -89,8 +89,8 @@ module NewGestionnaire
         notice = "Dossier considéré comme sans suite."
         template = procedure.without_continuation_mail_template
       when "accepter"
-        dossier.attestation = dossier.build_attestation
         dossier.accepte!
+        dossier.attestation = dossier.build_attestation
         notice = "Dossier traité avec succès."
         template = procedure.closed_mail_template
       end

--- a/app/models/concerns/tags_substitution_concern.rb
+++ b/app/models/concerns/tags_substitution_concern.rb
@@ -25,6 +25,7 @@ module TagsSubstitutionConcern
      { libelle: 'date de décision',
        description: 'Date de la décision d’acceptation, refus, ou classement sans suite',
        lambda: -> (d) { d.processed_at.present? ? d.processed_at.localtime.strftime('%d/%m/%Y') : '' } },
+     { libelle: 'libellé procédure', description: '', lambda: -> (d) { d.procedure.libelle } },
      { libelle: 'numéro du dossier', description: '', target: :id }]
   end
 

--- a/app/models/concerns/tags_substitution_concern.rb
+++ b/app/models/concerns/tags_substitution_concern.rb
@@ -19,7 +19,12 @@ module TagsSubstitutionConcern
   end
 
   def dossier_tags
-    [{ libelle: 'motivation', description: '', target: :motivation },
+    [{ libelle: 'motivation',
+       description: 'Motivation facultative associée à la décision finale d’acceptation, refus ou classement sans suite',
+       target: :motivation },
+     { libelle: 'date de décision',
+       description: 'Date de la décision d’acceptation, refus, ou classement sans suite',
+       lambda: -> (d) { d.processed_at.present? ? d.processed_at.localtime.strftime('%d/%m/%Y') : '' } },
      { libelle: 'numéro du dossier', description: '', target: :id }]
   end
 
@@ -70,7 +75,12 @@ module TagsSubstitutionConcern
   def replace_tags_with_values_from_data(text, tags, data)
     if data.present?
       tags.inject(text) do |acc, tag|
-        replace_tag(acc, tag, data.send(tag[:target]))
+        if tag.key?(:target)
+          value = data.send(tag[:target])
+        else
+          value = tag[:lambda].(data)
+        end
+        replace_tag(acc, tag, value)
       end
     else
       text

--- a/spec/controllers/backoffice/dossiers_controller_spec.rb
+++ b/spec/controllers/backoffice/dossiers_controller_spec.rb
@@ -358,10 +358,14 @@ describe Backoffice::DossiersController, type: :controller do
         subject { post :process_dossier, params: { process_action: "close", dossier_id: dossier_id, dossier: { motivation: "Yallah" }}}
 
         before do
+          Timecop.freeze(DateTime.now)
+
           expect_any_instance_of(AttestationTemplate)
             .to receive(:attestation_for)
-            .with(have_attributes(motivation: "Yallah"))
+            .with(have_attributes(motivation: "Yallah", processed_at: DateTime.now))
         end
+
+        after { Timecop.return }
 
         it { subject }
       end

--- a/spec/controllers/new_gestionnaire/dossiers_controller_spec.rb
+++ b/spec/controllers/new_gestionnaire/dossiers_controller_spec.rb
@@ -237,10 +237,14 @@ describe NewGestionnaire::DossiersController, type: :controller do
         end
 
         before do
+          Timecop.freeze(DateTime.now)
+
           expect_any_instance_of(AttestationTemplate)
             .to receive(:attestation_for)
-            .with(have_attributes(motivation: "Yallah"))
+            .with(have_attributes(motivation: "Yallah", processed_at: DateTime.now))
         end
+
+        after { Timecop.return }
 
         it { subject }
       end

--- a/spec/models/concern/tags_substitution_concern_spec.rb
+++ b/spec/models/concern/tags_substitution_concern_spec.rb
@@ -5,6 +5,7 @@ describe TagsSubstitutionConcern, type: :model do
 
   let(:procedure) do
     create(:procedure,
+      libelle: 'Une magnifique procédure',
       types_de_champ: types_de_champ,
       types_de_champ_private: types_de_champ_private,
       for_individual: for_individual)
@@ -170,6 +171,12 @@ describe TagsSubstitutionConcern, type: :model do
        before { dossier.accepte! }
 
        it { is_expected.to eq(DateTime.now.localtime.strftime('%d/%m/%Y')) }
+    end
+
+    context "when the template has a libellé procédure tag" do
+      let(:template) { 'body --libellé procédure--' }
+
+      it { is_expected.to eq('body Une magnifique procédure') }
     end
 
     context "match breaking and non breaking spaces" do

--- a/spec/models/concern/tags_substitution_concern_spec.rb
+++ b/spec/models/concern/tags_substitution_concern_spec.rb
@@ -164,6 +164,14 @@ describe TagsSubstitutionConcern, type: :model do
       end
     end
 
+    context "when the template has a date de décision tag" do
+      let(:template) { '--date de décision--' }
+
+       before { dossier.accepte! }
+
+       it { is_expected.to eq(DateTime.now.localtime.strftime('%d/%m/%Y')) }
+    end
+
     context "match breaking and non breaking spaces" do
       before { dossier.champs.first.update_attributes(value: 'valeur') }
 
@@ -193,5 +201,11 @@ describe TagsSubstitutionConcern, type: :model do
         it_behaves_like "treat all kinds of space as equivalent"
       end
     end
+  end
+
+  describe 'tags' do
+    subject { template_concern.tags }
+
+    it { is_expected.to include(include({ libelle: 'date de décision' })) }
   end
 end


### PR DESCRIPTION
Rend le libellé de procédure et la date de décision disponibles comme tags dans les templates d’attestation