### PR TITLE
Fix 1110 3. align mail and document templates

### DIFF
--- a/app/models/concerns/mail_template_concern.rb
+++ b/app/models/concerns/mail_template_concern.rb
@@ -41,9 +41,9 @@ module MailTemplateConcern
   end
 
   module ClassMethods
-    def default
+    def default_for_procedure(procedure)
       body = ActionController::Base.new.render_to_string(template: self.const_get(:TEMPLATE_NAME))
-      self.new(object: self.const_get(:DEFAULT_OBJECT), body: body)
+      self.new(object: self.const_get(:DEFAULT_OBJECT), body: body, procedure: procedure)
     end
   end
 

--- a/app/models/concerns/mail_template_concern.rb
+++ b/app/models/concerns/mail_template_concern.rb
@@ -6,24 +6,24 @@ module MailTemplateConcern
 
   TAGS = []
   TAGS << TAG_NUMERO_DOSSIER = {
-    name:         "numero_dossier",
-    description:  "Permet d'afficher le numéro de dossier de l'utilisateur."
+    libelle:     "numero_dossier",
+    description: "Permet d'afficher le numéro de dossier de l'utilisateur."
   }
   TAGS << TAG_LIEN_DOSSIER = {
-    name:         "lien_dossier",
-    description:  "Permet d'afficher un lien vers le dossier de l'utilisateur."
+    libelle:     "lien_dossier",
+    description: "Permet d'afficher un lien vers le dossier de l'utilisateur."
   }
   TAGS << TAG_LIBELLE_PROCEDURE = {
-    name:         "libelle_procedure",
-    description:  "Permet d'afficher le libellé de la procédure."
+    libelle:     "libelle_procedure",
+    description: "Permet d'afficher le libellé de la procédure."
   }
   TAGS << TAG_DATE_DE_DECISION = {
-    name:         "date_de_decision",
-    description:  "Permet d'afficher la date à laquelle la décision finale (acceptation, refus, classement sans suite) sur le dossier a été prise."
+    libelle:     "date_de_decision",
+    description: "Permet d'afficher la date à laquelle la décision finale (acceptation, refus, classement sans suite) sur le dossier a été prise."
   }
   TAGS << TAG_MOTIVATION = {
-    name:         "motivation",
-    description:  "Permet d'afficher la motivation associée à la décision finale (acceptation, refus, classement sans suite) sur le dossier. Attention, elle est facultative."
+    libelle:     "motivation",
+    description: "Permet d'afficher la motivation associée à la décision finale (acceptation, refus, classement sans suite) sur le dossier. Attention, elle est facultative."
   }
 
   def object_for_dossier(dossier)
@@ -36,7 +36,7 @@ module MailTemplateConcern
 
   def replace_tags(string, dossier)
     TAGS.inject(string) do |acc, tag|
-      acc.gsub("--#{tag[:name]}--", replace_tag(tag, dossier)) || acc
+      acc.gsub("--#{tag[:libelle]}--", replace_tag(tag, dossier)) || acc
     end
   end
 

--- a/app/models/concerns/mail_template_concern.rb
+++ b/app/models/concerns/mail_template_concern.rb
@@ -34,6 +34,10 @@ module MailTemplateConcern
     replace_tags(body, dossier)
   end
 
+  def tags
+    self.class.const_get(:ALLOWED_TAGS)
+  end
+
   def replace_tags(string, dossier)
     TAGS.inject(string) do |acc, tag|
       acc.gsub("--#{tag[:libelle]}--", replace_tag(tag, dossier)) || acc

--- a/app/models/mails/closed_mail.rb
+++ b/app/models/mails/closed_mail.rb
@@ -2,6 +2,8 @@ module Mails
   class ClosedMail < ApplicationRecord
     include MailTemplateConcern
 
+    belongs_to :procedure
+
     SLUG = "closed_mail"
     TEMPLATE_NAME = "mails/closed_mail"
     DISPLAYED_NAME = "Accusé d'acceptation"

--- a/app/models/mails/initiated_mail.rb
+++ b/app/models/mails/initiated_mail.rb
@@ -2,6 +2,8 @@ module Mails
   class InitiatedMail < ApplicationRecord
     include MailTemplateConcern
 
+    belongs_to :procedure
+
     SLUG = "initiated_mail"
     TEMPLATE_NAME = "mails/initiated_mail"
     DISPLAYED_NAME = 'Accusé de réception'

--- a/app/models/mails/received_mail.rb
+++ b/app/models/mails/received_mail.rb
@@ -2,6 +2,8 @@ module Mails
   class ReceivedMail < ApplicationRecord
     include MailTemplateConcern
 
+    belongs_to :procedure
+
     SLUG = "received_mail"
     TEMPLATE_NAME = "mails/received_mail"
     DISPLAYED_NAME = 'Accusé de passage en instruction'

--- a/app/models/mails/refused_mail.rb
+++ b/app/models/mails/refused_mail.rb
@@ -2,6 +2,8 @@ module Mails
   class RefusedMail < ApplicationRecord
     include MailTemplateConcern
 
+    belongs_to :procedure
+
     SLUG = "refused_mail"
     TEMPLATE_NAME = "mails/refused_mail"
     DISPLAYED_NAME = 'Accusé de rejet du dossier'

--- a/app/models/mails/without_continuation_mail.rb
+++ b/app/models/mails/without_continuation_mail.rb
@@ -2,6 +2,8 @@ module Mails
   class WithoutContinuationMail < ApplicationRecord
     include MailTemplateConcern
 
+    belongs_to :procedure
+
     SLUG = "without_continuation"
     TEMPLATE_NAME = "mails/without_continuation_mail"
     DISPLAYED_NAME = 'Accusé de classement sans suite'

--- a/app/models/procedure.rb
+++ b/app/models/procedure.rb
@@ -167,23 +167,23 @@ class Procedure < ActiveRecord::Base
   end
 
   def initiated_mail_template
-    initiated_mail || Mails::InitiatedMail.default
+    initiated_mail || Mails::InitiatedMail.default_for_procedure(self)
   end
 
   def received_mail_template
-    received_mail || Mails::ReceivedMail.default
+    received_mail || Mails::ReceivedMail.default_for_procedure(self)
   end
 
   def closed_mail_template
-    closed_mail || Mails::ClosedMail.default
+    closed_mail || Mails::ClosedMail.default_for_procedure(self)
   end
 
   def refused_mail_template
-    refused_mail || Mails::RefusedMail.default
+    refused_mail || Mails::RefusedMail.default_for_procedure(self)
   end
 
   def without_continuation_mail_template
-    without_continuation_mail || Mails::WithoutContinuationMail.default
+    without_continuation_mail || Mails::WithoutContinuationMail.default_for_procedure(self)
   end
 
   def fields

--- a/app/views/admin/mail_templates/edit.html.haml
+++ b/app/views/admin/mail_templates/edit.html.haml
@@ -22,7 +22,7 @@
             Balise
           %th
             Description
-        - @mail_template.class.const_get(:ALLOWED_TAGS).each do |tag|
+        - @mail_template.tags.each do |tag|
           %tr
             %td.center
               = "--#{tag[:libelle]}--"

--- a/app/views/admin/mail_templates/edit.html.haml
+++ b/app/views/admin/mail_templates/edit.html.haml
@@ -25,6 +25,6 @@
         - @mail_template.class.const_get(:ALLOWED_TAGS).each do |tag|
           %tr
             %td.center
-              = "--#{tag[:name]}--"
+              = "--#{tag[:libelle]}--"
             %td
               = tag[:description]

--- a/spec/controllers/admin/mail_templates_controller_spec.rb
+++ b/spec/controllers/admin/mail_templates_controller_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe Admin::MailTemplatesController, type: :controller do
-  let(:initiated_mail) { Mails::InitiatedMail.default }
   let(:procedure) { create :procedure }
+  let(:initiated_mail) { Mails::InitiatedMail.default_for_procedure(procedure) }
 
   before do
     sign_in procedure.administrateur

--- a/spec/models/concern/mail_template_concern_spec.rb
+++ b/spec/models/concern/mail_template_concern_spec.rb
@@ -1,9 +1,10 @@
 require 'spec_helper'
 
 describe MailTemplateConcern do
-  let(:dossier) { create :dossier }
-  let(:dossier2) { create :dossier }
-  let(:initiated_mail) { Mails::InitiatedMail.default }
+  let(:procedure) { create(:procedure)}
+  let(:dossier) { create(:dossier, procedure: procedure) }
+  let(:dossier2) { create(:dossier, procedure: procedure) }
+  let(:initiated_mail) { Mails::InitiatedMail.default_for_procedure(procedure) }
 
   shared_examples "can replace tokens in template" do
     describe 'with no token to replace' do

--- a/spec/models/procedure_spec.rb
+++ b/spec/models/procedure_spec.rb
@@ -12,10 +12,12 @@ describe Procedure do
   end
 
   describe 'initiated_mail' do
-    subject { create(:procedure) }
+    let(:procedure) { create(:procedure) }
+
+    subject { procedure }
 
     context 'when initiated_mail is not customize' do
-      it { expect(subject.initiated_mail_template.body).to eq(Mails::InitiatedMail.default.body) }
+      it { expect(subject.initiated_mail_template.body).to eq(Mails::InitiatedMail.default_for_procedure(procedure).body) }
     end
 
     context 'when initiated_mail is customize' do
@@ -209,7 +211,7 @@ describe Procedure do
     end
 
     it 'should not duplicate default mail_template' do
-      expect(subject.initiated_mail_template.attributes).to eq Mails::InitiatedMail.default.attributes
+      expect(subject.initiated_mail_template.attributes).to eq Mails::InitiatedMail.default_for_procedure(subject).attributes
     end
 
     it 'should not duplicate specific related objects' do


### PR DESCRIPTION
Cleanup pour rapprocher l'interface des templates de mail et celle des templates du moteur générique, afin de faciliter la bascule