### PR TITLE
Fix 1110 4. port attestation tags to mail

### DIFF
--- a/app/models/concerns/mail_template_concern.rb
+++ b/app/models/concerns/mail_template_concern.rb
@@ -3,28 +3,7 @@ module MailTemplateConcern
 
   include Rails.application.routes.url_helpers
   include ActionView::Helpers::UrlHelper
-
-  TAGS = []
-  TAGS << TAG_NUMERO_DOSSIER = {
-    libelle:     "numero_dossier",
-    description: "Permet d'afficher le numéro de dossier de l'utilisateur."
-  }
-  TAGS << TAG_LIEN_DOSSIER = {
-    libelle:     "lien_dossier",
-    description: "Permet d'afficher un lien vers le dossier de l'utilisateur."
-  }
-  TAGS << TAG_LIBELLE_PROCEDURE = {
-    libelle:     "libelle_procedure",
-    description: "Permet d'afficher le libellé de la procédure."
-  }
-  TAGS << TAG_DATE_DE_DECISION = {
-    libelle:     "date_de_decision",
-    description: "Permet d'afficher la date à laquelle la décision finale (acceptation, refus, classement sans suite) sur le dossier a été prise."
-  }
-  TAGS << TAG_MOTIVATION = {
-    libelle:     "motivation",
-    description: "Permet d'afficher la motivation associée à la décision finale (acceptation, refus, classement sans suite) sur le dossier. Attention, elle est facultative."
-  }
+  include TagsSubstitutionConcern
 
   def object_for_dossier(dossier)
     replace_tags(object, dossier)
@@ -34,14 +13,10 @@ module MailTemplateConcern
     replace_tags(body, dossier)
   end
 
-  def tags
-    self.class.const_get(:ALLOWED_TAGS)
-  end
-
-  def replace_tags(string, dossier)
-    TAGS.inject(string) do |acc, tag|
-      acc.gsub("--#{tag[:libelle]}--", replace_tag(tag, dossier)) || acc
-    end
+  # TODO: remove legacy argument when removing legacy tags
+  def tags(reject_legacy: true, is_dossier_termine: self.class.const_get(:IS_DOSSIER_TERMINE))
+    super(is_dossier_termine: is_dossier_termine)
+      .reject { |tag| reject_legacy && tag[:is_legacy] }
   end
 
   module ClassMethods
@@ -53,20 +28,20 @@ module MailTemplateConcern
 
   private
 
-  def replace_tag(tag, dossier)
-    case tag
-    when TAG_NUMERO_DOSSIER
-      dossier.id.to_s
-    when TAG_LIEN_DOSSIER
-      link_to users_dossier_recapitulatif_url(dossier), users_dossier_recapitulatif_url(dossier), target: '_blank'
-    when TAG_LIBELLE_PROCEDURE
-      dossier.procedure.libelle
-    when TAG_DATE_DE_DECISION
-      dossier.processed_at.present? ? dossier.processed_at.localtime.strftime("%d/%m/%Y") : ""
-    when TAG_MOTIVATION
-      dossier.motivation || ""
-    else
-      '--BALISE_NON_RECONNUE--'
-    end
+  def dossier_tags
+    super +
+      [{ libelle: 'lien dossier', description: '', lambda: -> (d) { users_dossier_recapitulatif_link(d) } },
+       # TODO: remove legacy tags
+       { libelle: 'numero_dossier', description: '', target: :id, is_legacy: true },
+       { libelle: 'lien_dossier', description: '', lambda: -> (d) { users_dossier_recapitulatif_link(d) }, is_legacy: true },
+       { libelle: 'libelle_procedure', description: '', lambda: -> (d) { d.procedure.libelle }, is_legacy: true },
+       { libelle: 'date_de_decision', description: '',
+         lambda: -> (d) { d.processed_at.present? ? d.processed_at.localtime.strftime('%d/%m/%Y') : '' },
+         dossier_termine_only: true, is_legacy: true }]
+  end
+
+  def users_dossier_recapitulatif_link(dossier)
+    url = users_dossier_recapitulatif_url(dossier)
+    link_to(url, url, target: '_blank')
   end
 end

--- a/app/models/mails/closed_mail.rb
+++ b/app/models/mails/closed_mail.rb
@@ -8,6 +8,6 @@ module Mails
     TEMPLATE_NAME = "mails/closed_mail"
     DISPLAYED_NAME = "Accusé d'acceptation"
     DEFAULT_OBJECT = 'Votre dossier TPS nº --numero_dossier-- a été accepté'
-    ALLOWED_TAGS = [TAG_NUMERO_DOSSIER, TAG_LIEN_DOSSIER, TAG_LIBELLE_PROCEDURE, TAG_DATE_DE_DECISION, TAG_MOTIVATION]
+    IS_DOSSIER_TERMINE = true
   end
 end

--- a/app/models/mails/closed_mail.rb
+++ b/app/models/mails/closed_mail.rb
@@ -7,7 +7,7 @@ module Mails
     SLUG = "closed_mail"
     TEMPLATE_NAME = "mails/closed_mail"
     DISPLAYED_NAME = "Accusé d'acceptation"
-    DEFAULT_OBJECT = 'Votre dossier TPS nº --numero_dossier-- a été accepté'
+    DEFAULT_OBJECT = 'Votre dossier TPS nº --numéro du dossier-- a été accepté'
     IS_DOSSIER_TERMINE = true
   end
 end

--- a/app/models/mails/initiated_mail.rb
+++ b/app/models/mails/initiated_mail.rb
@@ -7,7 +7,7 @@ module Mails
     SLUG = "initiated_mail"
     TEMPLATE_NAME = "mails/initiated_mail"
     DISPLAYED_NAME = 'Accusé de réception'
-    DEFAULT_OBJECT = 'Votre dossier TPS nº --numero_dossier-- a bien été reçu'
+    DEFAULT_OBJECT = 'Votre dossier TPS nº --numéro du dossier-- a bien été reçu'
     IS_DOSSIER_TERMINE = false
   end
 end

--- a/app/models/mails/initiated_mail.rb
+++ b/app/models/mails/initiated_mail.rb
@@ -8,6 +8,6 @@ module Mails
     TEMPLATE_NAME = "mails/initiated_mail"
     DISPLAYED_NAME = 'Accusé de réception'
     DEFAULT_OBJECT = 'Votre dossier TPS nº --numero_dossier-- a bien été reçu'
-    ALLOWED_TAGS = [TAG_NUMERO_DOSSIER, TAG_LIEN_DOSSIER, TAG_LIBELLE_PROCEDURE]
+    IS_DOSSIER_TERMINE = false
   end
 end

--- a/app/models/mails/received_mail.rb
+++ b/app/models/mails/received_mail.rb
@@ -7,7 +7,7 @@ module Mails
     SLUG = "received_mail"
     TEMPLATE_NAME = "mails/received_mail"
     DISPLAYED_NAME = 'Accusé de passage en instruction'
-    DEFAULT_OBJECT = 'Votre dossier TPS nº --numero_dossier-- va être instruit'
+    DEFAULT_OBJECT = 'Votre dossier TPS nº --numéro du dossier-- va être instruit'
     IS_DOSSIER_TERMINE = false
   end
 end

--- a/app/models/mails/received_mail.rb
+++ b/app/models/mails/received_mail.rb
@@ -8,6 +8,6 @@ module Mails
     TEMPLATE_NAME = "mails/received_mail"
     DISPLAYED_NAME = 'Accusé de passage en instruction'
     DEFAULT_OBJECT = 'Votre dossier TPS nº --numero_dossier-- va être instruit'
-    ALLOWED_TAGS = [TAG_NUMERO_DOSSIER, TAG_LIEN_DOSSIER, TAG_LIBELLE_PROCEDURE]
+    IS_DOSSIER_TERMINE = false
   end
 end

--- a/app/models/mails/refused_mail.rb
+++ b/app/models/mails/refused_mail.rb
@@ -8,6 +8,6 @@ module Mails
     TEMPLATE_NAME = "mails/refused_mail"
     DISPLAYED_NAME = 'Accusé de rejet du dossier'
     DEFAULT_OBJECT = 'Votre dossier TPS nº --numero_dossier-- a été refusé'
-    ALLOWED_TAGS = [TAG_NUMERO_DOSSIER, TAG_LIEN_DOSSIER, TAG_LIBELLE_PROCEDURE, TAG_DATE_DE_DECISION, TAG_MOTIVATION]
+    IS_DOSSIER_TERMINE = true
   end
 end

--- a/app/models/mails/refused_mail.rb
+++ b/app/models/mails/refused_mail.rb
@@ -7,7 +7,7 @@ module Mails
     SLUG = "refused_mail"
     TEMPLATE_NAME = "mails/refused_mail"
     DISPLAYED_NAME = 'Accusé de rejet du dossier'
-    DEFAULT_OBJECT = 'Votre dossier TPS nº --numero_dossier-- a été refusé'
+    DEFAULT_OBJECT = 'Votre dossier TPS nº --numéro du dossier-- a été refusé'
     IS_DOSSIER_TERMINE = true
   end
 end

--- a/app/models/mails/without_continuation_mail.rb
+++ b/app/models/mails/without_continuation_mail.rb
@@ -7,7 +7,7 @@ module Mails
     SLUG = "without_continuation"
     TEMPLATE_NAME = "mails/without_continuation_mail"
     DISPLAYED_NAME = 'Accusé de classement sans suite'
-    DEFAULT_OBJECT = 'Votre dossier TPS nº --numero_dossier-- a été classé sans suite'
+    DEFAULT_OBJECT = 'Votre dossier TPS nº --numéro du dossier-- a été classé sans suite'
     IS_DOSSIER_TERMINE = true
   end
 end

--- a/app/models/mails/without_continuation_mail.rb
+++ b/app/models/mails/without_continuation_mail.rb
@@ -8,6 +8,6 @@ module Mails
     TEMPLATE_NAME = "mails/without_continuation_mail"
     DISPLAYED_NAME = 'Accusé de classement sans suite'
     DEFAULT_OBJECT = 'Votre dossier TPS nº --numero_dossier-- a été classé sans suite'
-    ALLOWED_TAGS = [TAG_NUMERO_DOSSIER, TAG_LIEN_DOSSIER, TAG_LIBELLE_PROCEDURE, TAG_DATE_DE_DECISION, TAG_MOTIVATION]
+    IS_DOSSIER_TERMINE = true
   end
 end

--- a/app/views/mails/closed_mail.html.haml
+++ b/app/views/mails/closed_mail.html.haml
@@ -1,10 +1,10 @@
 Bonjour,
 %br
 %br
-Votre dossier nº --numero_dossier-- a été accepté le --date_de_decision--.
+Votre dossier nº --numéro du dossier-- a été accepté le --date de décision--.
 %br
 %br
-A tout moment, vous pouvez consulter le contenu de vos dossiers et les éventuels commentaires de l'administration à cette adresse : --lien_dossier--
+A tout moment, vous pouvez consulter le contenu de vos dossiers et les éventuels commentaires de l'administration à cette adresse : --lien dossier--
 %br
 %br
 Bonne journée,

--- a/app/views/mails/initiated_mail.html.haml
+++ b/app/views/mails/initiated_mail.html.haml
@@ -1,10 +1,10 @@
 Bonjour,
 %br
 %br
-Votre administration vous confirme la bonne réception de votre dossier nº --numero_dossier--.
+Votre administration vous confirme la bonne réception de votre dossier nº --numéro du dossier--.
 %br
 %br
-A tout moment, vous pouvez consulter le contenu de vos dossiers et les éventuels commentaires de l'administration à cette adresse : --lien_dossier--
+A tout moment, vous pouvez consulter le contenu de vos dossiers et les éventuels commentaires de l'administration à cette adresse : --lien dossier--
 %br
 %br
 Bonne journée,

--- a/app/views/mails/received_mail.html.haml
+++ b/app/views/mails/received_mail.html.haml
@@ -1,7 +1,7 @@
 Bonjour,
 %br
 %br
-Votre administration vous confirme la bonne réception de votre dossier nº --numero_dossier--. Celui-ci sera instruit dans le délai légal déclaré par votre interlocuteur.
+Votre administration vous confirme la bonne réception de votre dossier nº --numéro du dossier--. Celui-ci sera instruit dans le délai légal déclaré par votre interlocuteur.
 %br
 %br
 Bonne journée,

--- a/app/views/mails/refused_mail.html.haml
+++ b/app/views/mails/refused_mail.html.haml
@@ -1,10 +1,10 @@
 Bonjour,
 %br
 %br
-Votre dossier nº --numero_dossier-- a été refusé le --date_de_decision--.
+Votre dossier nº --numéro du dossier-- a été refusé le --date de décision--.
 %br
 %br
-Pour en savoir plus sur le motif du refus, vous pouvez consulter le contenu de vos dossiers et les éventuels commentaires de l'administration à cette adresse : --lien_dossier--
+Pour en savoir plus sur le motif du refus, vous pouvez consulter le contenu de vos dossiers et les éventuels commentaires de l'administration à cette adresse : --lien dossier--
 %br
 %br
 Bonne journée,

--- a/app/views/mails/without_continuation_mail.html.haml
+++ b/app/views/mails/without_continuation_mail.html.haml
@@ -1,10 +1,10 @@
 Bonjour,
 %br
 %br
-Votre dossier nº --numero_dossier-- a été classé sans suite le --date_de_decision--.
+Votre dossier nº --numéro du dossier-- a été classé sans suite le --date de décision--.
 %br
 %br
-Pour en savoir plus sur les raisons de ce classement sans suite, vous pouvez consulter le contenu de vos dossiers et les éventuels commentaires de l'administration à cette adresse : --lien_dossier--
+Pour en savoir plus sur les raisons de ce classement sans suite, vous pouvez consulter le contenu de vos dossiers et les éventuels commentaires de l'administration à cette adresse : --lien dossier--
 %br
 %br
 Bonne journée,

--- a/lib/tasks/2017_12_21_replace_deprecated_mail_template_tags.rake
+++ b/lib/tasks/2017_12_21_replace_deprecated_mail_template_tags.rake
@@ -1,0 +1,22 @@
+namespace :'2017_12_21_replace_deprecated_mail_template_tags' do
+  task set: :environment do
+    replace_tag('numero_dossier', 'numéro du dossier')
+    replace_tag('date_de_decision', 'date de décision')
+    replace_tag('libelle_procedure', 'libellé procédure')
+    replace_tag('lien_dossier', 'lien dossier')
+  end
+
+  def replace_tag(old_tag, new_tag)
+    mails = [ Mails::ClosedMail, Mails::InitiatedMail, Mails::ReceivedMail, Mails::RefusedMail, Mails::WithoutContinuationMail]
+    mails.each do |mail|
+      replace_tag_in(mail, 'object', old_tag, new_tag)
+      replace_tag_in(mail, 'body', old_tag, new_tag)
+    end
+  end
+
+  def replace_tag_in(mail, field, old_tag, new_tag)
+    mail
+      .where("#{field} LIKE ?", "%#{old_tag}%")
+      .update_all("#{field} = REPLACE(#{field}, '#{old_tag}', '#{new_tag}')")
+  end
+end

--- a/spec/factories/mail_templates.rb
+++ b/spec/factories/mail_templates.rb
@@ -1,21 +1,15 @@
 FactoryGirl.define do
-  factory :mail_template do
+  factory :mail_template, class: Mails::ClosedMail do
     object "Object, voila voila"
     body "Blabla ceci est mon body"
-    type 'MailValidated'
 
-    trait :dossier_submitted do
-      type 'MailSubmitted'
-    end
+    factory :dossier_submitted_mail_template, class: Mails::ReceivedMail
 
-    trait :dossier_refused do
-      type 'MailRefused'
-    end
+    factory :dossier_refused_mail_template, class: Mails::RefusedMail
 
-    trait :dossier_en_instruction do
+    factory :dossier_en_instruction_mail_template, class: Mails::InitiatedMail do
       object "[TPS] Accusé de réception pour votre dossier nº --numero_dossier--"
       body "Votre administration vous confirme la bonne réception de votre dossier nº --numero_dossier--"
-      type 'MailReceived'
     end
   end
 end

--- a/spec/factories/mail_templates.rb
+++ b/spec/factories/mail_templates.rb
@@ -8,8 +8,8 @@ FactoryGirl.define do
     factory :dossier_refused_mail_template, class: Mails::RefusedMail
 
     factory :dossier_en_instruction_mail_template, class: Mails::InitiatedMail do
-      object "[TPS] Accusé de réception pour votre dossier nº --numero_dossier--"
-      body "Votre administration vous confirme la bonne réception de votre dossier nº --numero_dossier--"
+      object "[TPS] Accusé de réception pour votre dossier nº --numéro du dossier--"
+      body "Votre administration vous confirme la bonne réception de votre dossier nº --numéro du dossier--"
     end
   end
 end

--- a/spec/models/concern/mail_template_concern_spec.rb
+++ b/spec/models/concern/mail_template_concern_spec.rb
@@ -15,14 +15,14 @@ describe MailTemplateConcern do
     end
 
     describe 'with one token to replace' do
-      let(:template) { '[TPS] Dossier : --numero_dossier--' }
+      let(:template) { '[TPS] Dossier : --numéro du dossier--' }
       it do
         is_expected.to eq("[TPS] Dossier : #{dossier.id}")
       end
     end
 
     describe 'with multiples tokens to replace' do
-      let(:template) { '[TPS] --numero_dossier-- --libelle_procedure-- --lien_dossier--' }
+      let(:template) { '[TPS] --numéro du dossier-- --libellé procédure-- --lien dossier--' }
       it do
         expected =
           "[TPS] #{dossier.id} #{dossier.procedure.libelle} " +
@@ -48,10 +48,10 @@ describe MailTemplateConcern do
   end
 
   describe '.replace_tags' do
+    before { initiated_mail.body = "n --numéro du dossier--" }
     it "avoids side effects" do
-      subject = "n --numero_dossier--"
-      expect(initiated_mail.replace_tags(subject, dossier)).to eq("n #{dossier.id}")
-      expect(initiated_mail.replace_tags(subject, dossier2)).to eq("n #{dossier2.id}")
+      expect(initiated_mail.body_for_dossier(dossier)).to eq("n #{dossier.id}")
+      expect(initiated_mail.body_for_dossier(dossier2)).to eq("n #{dossier2.id}")
     end
   end
 end

--- a/spec/views/admin/mail_templates/edit.html.haml_spec.rb
+++ b/spec/views/admin/mail_templates/edit.html.haml_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe 'admin/mail_templates/edit.html.haml', type: :view do
+  let(:procedure) { create(:procedure) }
+  let(:mail_template) { create(:mail_template, procedure: procedure) }
+  let(:all_tags) { mail_template.tags(reject_legacy: false) }
+
+  before do
+    allow(view).to receive(:admin_procedure_mail_template_path).and_return("/toto")
+    allow(view).to receive(:admin_procedure_mail_templates_path).and_return("/toto")
+
+    assign(:mail_template, mail_template)
+  end
+
+  subject { render }
+
+  context "Legacy champs are not listed in the page" do
+    it { expect(all_tags).to include(include({ libelle: 'numero_dossier', is_legacy: true })) }
+    it { is_expected.not_to include("numero_dossier") }
+  end
+
+  context "Non-legacy champs are listed in the page" do
+    it { expect(all_tags).to include(include({ libelle: 'numéro du dossier' })) }
+    it { is_expected.to include("numéro du dossier") }
+  end
+end


### PR DESCRIPTION
Passe les mails sur le moteur de template générique, ce qui rend disponible de nouveaux tags dans les templates de mail