### PR TITLE
Fix 1110 5. remove legacy tags

### DIFF
--- a/app/models/concerns/mail_template_concern.rb
+++ b/app/models/concerns/mail_template_concern.rb
@@ -13,10 +13,8 @@ module MailTemplateConcern
     replace_tags(body, dossier)
   end
 
-  # TODO: remove legacy argument when removing legacy tags
-  def tags(reject_legacy: true, is_dossier_termine: self.class.const_get(:IS_DOSSIER_TERMINE))
-    super(is_dossier_termine: is_dossier_termine)
-      .reject { |tag| reject_legacy && tag[:is_legacy] }
+  def tags(is_dossier_termine: self.class.const_get(:IS_DOSSIER_TERMINE))
+    super
   end
 
   module ClassMethods
@@ -29,15 +27,7 @@ module MailTemplateConcern
   private
 
   def dossier_tags
-    super +
-      [{ libelle: 'lien dossier', description: '', lambda: -> (d) { users_dossier_recapitulatif_link(d) } },
-       # TODO: remove legacy tags
-       { libelle: 'numero_dossier', description: '', target: :id, is_legacy: true },
-       { libelle: 'lien_dossier', description: '', lambda: -> (d) { users_dossier_recapitulatif_link(d) }, is_legacy: true },
-       { libelle: 'libelle_procedure', description: '', lambda: -> (d) { d.procedure.libelle }, is_legacy: true },
-       { libelle: 'date_de_decision', description: '',
-         lambda: -> (d) { d.processed_at.present? ? d.processed_at.localtime.strftime('%d/%m/%Y') : '' },
-         dossier_termine_only: true, is_legacy: true }]
+    super + [{ libelle: 'lien dossier', description: '', lambda: -> (d) { users_dossier_recapitulatif_link(d) } }]
   end
 
   def users_dossier_recapitulatif_link(dossier)

--- a/spec/views/admin/mail_templates/edit.html.haml_spec.rb
+++ b/spec/views/admin/mail_templates/edit.html.haml_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'admin/mail_templates/edit.html.haml', type: :view do
   let(:procedure) { create(:procedure) }
   let(:mail_template) { create(:mail_template, procedure: procedure) }
-  let(:all_tags) { mail_template.tags(reject_legacy: false) }
+  let(:all_tags) { mail_template.tags }
 
   before do
     allow(view).to receive(:admin_procedure_mail_template_path).and_return("/toto")
@@ -12,15 +12,8 @@ describe 'admin/mail_templates/edit.html.haml', type: :view do
     assign(:mail_template, mail_template)
   end
 
-  subject { render }
-
-  context "Legacy champs are not listed in the page" do
-    it { expect(all_tags).to include(include({ libelle: 'numero_dossier', is_legacy: true })) }
-    it { is_expected.not_to include("numero_dossier") }
-  end
-
-  context "Non-legacy champs are listed in the page" do
+  context "Champs are listed in the page" do
     it { expect(all_tags).to include(include({ libelle: 'numéro du dossier' })) }
-    it { is_expected.to include("numéro du dossier") }
+    it { expect(render).to include("numéro du dossier") }
   end
 end


### PR DESCRIPTION
Suppression du code qui gérait les `vieux_tags_moches` des mails. 

:warning: À merger seulement après avoir exécuté la tâche rake qui les remplace par des `jolis nouveaux tags` dans les templates existants.
  