### PR TITLE
Replace old stub with new allow syntax

### DIFF
--- a/spec/controllers/administrations/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/administrations/omniauth_callbacks_controller_spec.rb
@@ -8,7 +8,7 @@ describe Administrations::OmniauthCallbacksController, type: :controller do
   describe 'POST #github' do
     let(:params) { { "info" => { "email" => email } } }
     before do
-      controller.stub(:sign_in).and_return true
+      allow(controller).to receive(:sign_in).and_return true
       @request.env["omniauth.auth"] = params
     end
     subject { post :github }

--- a/spec/views/new_gestionnaire/dossiers/print.html.haml_spec.rb
+++ b/spec/views/new_gestionnaire/dossiers/print.html.haml_spec.rb
@@ -7,7 +7,7 @@ describe 'new_gestionnaire/dossiers/print.html.haml', type: :view do
 
     before do
       assign(:dossier, dossier)
-      view.stub(:current_gestionnaire).and_return(current_gestionnaire)
+      allow(view).to receive(:current_gestionnaire).and_return(current_gestionnaire)
 
       render
     end

--- a/spec/views/new_gestionnaire/dossiers/show.html.haml_spec.rb
+++ b/spec/views/new_gestionnaire/dossiers/show.html.haml_spec.rb
@@ -8,7 +8,7 @@ describe 'new_gestionnaire/dossiers/show.html.haml', type: :view do
 
   before do
     assign(:dossier, dossier)
-    view.stub(:current_gestionnaire).and_return(current_gestionnaire)
+    allow(view).to receive(:current_gestionnaire).and_return(current_gestionnaire)
     render
   end
 


### PR DESCRIPTION
The goal is to get rid of this warning:

> Deprecation Warnings:
> 
> Using `stub` from rspec-mocks' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead.